### PR TITLE
Docs audit: align runtime and operations guides

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-Agentic Coder is a local-first, GitHub-native autonomous AI development platform. It runs as a self-hosted service that monitors a dedicated **control repository** on GitHub, picks up natural-language engineering tasks posted as issue comments, and autonomously plans, codes, reviews, and opens pull requests in one or more **target repositories** — all without requiring a public webhook endpoint.
+Agentic Coder is a local-first, GitHub-native autonomous AI development platform. It runs as a self-hosted service that monitors a dedicated **control repository** on GitHub, picks up natural-language engineering tasks posted as issue comments, and autonomously plans, retrieves context, reviews, and opens draft pull requests in one or more **target repositories** — all without requiring a public webhook endpoint.
 
 The platform is designed around a human-in-the-loop approval model: in `gated` mode (default), every proposed change waits for explicit sign-off via a GitHub comment before a PR is opened. In `autonomous` mode, the agent acts end-to-end without pausing.
+
+Current implementation note: the PR branch currently contains a run artifact (`.agentic/runs/<run_id>.md`) plus PR draft metadata. The pipeline does not yet write source-code edits into the target repository.
 
 ---
 
@@ -57,6 +59,13 @@ Create branch → commit artifact → open draft PR in target repo
 Post status update comment on source issue
 ```
 
+### Current Execution Semantics
+
+- The pipeline generates a `PatchProposal`, review result, security result, test plan, and PR draft
+- Approval and status comments are posted back to the control-repository issue when issue context is present
+- Target-repository PRs are currently artifact-backed and are intended as a controlled handoff / approval surface
+- Direct file patch application in the target repository is not implemented yet
+
 ---
 
 ## Data Model
@@ -91,6 +100,8 @@ RECEIVED → NORMALIZED → INDEXED → PLANNED → AWAITING_APPROVAL → READY 
 | `task_transitions` | Append-only log of every state change with reason and details |
 | `run_events` | Granular event timeline per run (plan_created, proposal_generated, pr_draft, etc.) |
 | `poll_cursors` | Durable per-repo polling position (last `updated_at` seen) |
+| `chat_sessions` | Persistent remote-operator chat sessions bound to target repositories |
+| `chat_messages` | Ordered transcript messages stored for each chat session |
 
 ---
 
@@ -205,6 +216,7 @@ version: 1
 
 system:
   name: agentic-coder
+  environment: development
   control_repository: owner/agentic_coder      # repo the agent polls for commands
   allow_any_target_repository: false           # must be false in production
   allowed_target_repositories:
@@ -232,6 +244,7 @@ autonomy:
 sandbox:
   profile: compose
   network_enabled: false
+  network_allowlist: []
   max_runtime_seconds: 900
   max_cpu_cores: 2
   max_memory_mb: 2048
@@ -250,7 +263,12 @@ knowledge_graph:
   enabled: true
   storage: postgres
   node_types: [repo, commit, file, symbol, test, issue, pr, task, artifact, decision]
-  edge_types: [contains, imports, depends_on, tests, resolves, generates]
+  edge_types: [contains, imports, defines, references, calls, changes, mentions, derived_from, related_to]
+
+budgets:
+  max_prompt_tokens: 32000
+  max_completion_tokens: 8000
+  max_parallel_candidates: 1
 ```
 
 ---
@@ -283,6 +301,7 @@ The platform now includes a first-class chat intake UI at `GET /chat` for remote
 - Persistent chat sessions are stored in PostgreSQL (`chat_sessions`, `chat_messages`)
 - Each session is bound to an allowed target repository
 - Operator identity is carried on each write via `X-Operator`
+- The page prompts for `X-Admin-Token` when `API_ADMIN_TOKEN` is configured
 - Session execution enqueues a normal task into the same pipeline and queue
 - Session transcripts are converted into task payloads with full run traceability
 
@@ -293,6 +312,7 @@ In `gated` autonomy mode, chat execution requires a GitHub approval issue number
 - Set `approval_issue_number` on session create, or pass it during execute
 - Worker posts approval-request/status comments to the control repository issue
 - `/approve` and `/reject` comments continue to drive transitions and PR creation
+- The resulting PR is still artifact-backed until direct patch application is implemented
 
 ### Installation Context Separation
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # Agentic Coder
 
-A local-first autonomous AI development platform scaffold.
+Agentic Coder is a local-first, GitHub-native agent orchestration service for turning remote requests into tracked engineering runs.
 
 ## Current status
 
-This repository contains the initial implementation foundation for:
+The current implementation includes:
 
-- FastAPI control plane
-- GitHub App webhook verification scaffolding
-- YAML-based autonomy policy
-- durable task state machine primitives
-- model provider abstraction
-- in-memory knowledge graph and retrieval prototypes
-- sandbox execution policy scaffolding
-- audit log primitives
+- FastAPI control plane with health, readiness, dashboard, timeline, and self-check endpoints
+- PostgreSQL-backed tasks, runs, run events, transitions, polling cursors, chat sessions, and chat messages
+- Worker polling against a dedicated control repository with remote `/approve` and `/reject` handling
+- GitHub App integration for status comments, approval comments, branch creation, and draft PR opening
+- Chat control plane at `/chat` for remote operator-driven task intake
+- Automated regression, smoke, and CI coverage
+
+## Current execution scope
+
+The pipeline currently plans, retrieves context, reviews, generates validation commands, and drafts PR metadata.
+
+- The current PR flow is artifact-backed: it creates a target-repo branch, commits `.agentic/runs/<run_id>.md`, and opens a draft PR
+- It does not yet apply generated source-code edits into the target repository
+- That limitation should be kept in mind when operating the system or evaluating run results
 
 ## Development workflow
 
@@ -58,9 +64,22 @@ Notes:
 ### Initial bootstrap
 
 1. `make bootstrap`
-2. `make test`
+2. `make qa`
 
-Webhook task ingestion now persists tasks in PostgreSQL and enqueues task IDs in Redis for worker processing.
+`make bootstrap` starts the stack, applies migrations, and runs the GitHub startup self-check. `make qa` then runs lint, tests, and live smoke validation.
+
+### Operating the system
+
+There are two supported operator paths:
+
+- GitHub comment workflow: comment on the control repository with `@agent repo=...` or `/repo ...`
+- Chat workflow: open `http://localhost:8080/chat` and create a session for an allowed target repository
+
+Remote approvals remain GitHub-native in `gated` mode:
+
+- Comment `/approve` or `/approve <task_id>` on the control-repo issue thread
+- Comment `/reject <task_id> reason` or `/reject reason`
+- Chat executions in `gated` mode require an approval issue number so the worker knows where to post approval and status comments
 
 ### GitHub PR workflow
 
@@ -69,7 +88,7 @@ The API supports creating a draft PR from an existing run timeline:
 - `POST /runs/{run_id}/pull-request`
 - body: `{"installation_id": <int>, "branch_name": "agentic/<run>", "draft": true}`
 
-This flow uses GitHub App installation token exchange, resolves the repository default branch, creates the head branch, and opens a draft PR using run-generated PR draft metadata.
+This flow uses GitHub App installation token exchange, resolves the repository default branch, creates the head branch, commits the run artifact, and opens a draft PR using run-generated PR draft metadata.
 
 ### Control repo vs target repos
 
@@ -119,12 +138,14 @@ Example:
 
 Primary configuration is in [agentic.yaml](agentic.yaml):
 
-- `models.primary_provider`: set to `auto` (current default)
+- `models.primary_provider`: current default is `github`
 - `models.fallback_provider`: fallback model path
 - `system.allow_any_target_repository`: broad target access toggle
 - `system.allowed_target_repositories`: explicit allowlist (supports `owner/repo` or bare repo name)
 
 Current defaults are configured to allow only `predictiv` as a target repository.
+
+The current local environment is configured to use `Phi-4` via `GITHUB_MODELS_CHAT_MODEL`.
 
 ### Startup self-check
 
@@ -179,7 +200,7 @@ If `make` is unavailable, use direct Compose commands:
 
 - `docker compose up --build -d`
 - `docker compose run --rm api pytest`
-- `docker compose run --rm api ruff check src tests`
+- `docker compose run --rm api ruff check src tests scripts`
 - `docker compose run --rm -e BASE_URL=http://api:8080 api python scripts/smoke_test.py --base-url http://api:8080 --target-repository predictiv`
 
 The repository includes a `.devcontainer` configuration so VS Code can attach directly to the `api` service and use the container interpreter for analysis and testing.
@@ -188,10 +209,9 @@ The repository includes a `.devcontainer` configuration so VS Code can attach di
 
 A host Python environment is optional and only needed if container-based development is not desired.
 
-## Immediate next steps
+## Recommended next investments
 
-- add PostgreSQL-backed persistence
-- wire Redis queue and worker loop
-- implement GitHub App installation token flow
-- persist audit events and graph state
-- replace prototype retrieval with pgvector-backed hybrid search
+- Add real patch application so target-repo PRs contain source edits instead of only run artifacts
+- Execute generated validation commands in the sandbox executor before PR open
+- Reduce worker idle-log noise or make polling log verbosity configurable
+- Strengthen retrieval and knowledge-graph quality beyond the current `.py`-centric heuristics

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,110 +1,86 @@
-# Usage Guide: Agentic Coder Polling Workflow
+# Usage Guide: GitHub Comment and Chat Workflows
 
-## Triggering Tasks via GitHub Comments
+## GitHub comment workflow
 
-1. **Go to your control repository:**
-   - Navigate to `italnstallion789/agentic_coder` on GitHub.
+1. Open an issue in the control repository: `italnstallion789/agentic_coder`.
+2. Add a request comment with an agent command, for example:
 
-2. **Open an issue or pull request:**
-   - You can use an existing issue/PR or create a new one.
-
-3. **Add a comment with an agent command:**
-   - To trigger the agent, include `@agent` or `repo=...` in your comment. Example:
-
-     ```
-     @agent repo=italnstallion789/predictiv
-     Please implement a function to add two numbers in the target repo.
-     ```
-
-   - Or:
-
-     ```
-     /repo italnstallion789/predictiv
-     Add a README badge for build status.
-     ```
-
-4. **Agent polling and task creation:**
-   - The agent polls for new comments in the control repo.
-   - When it detects a valid command, it creates a task for the specified target repository.
-
-5. **Monitor task status:**
-   - Use API endpoints or logs to track task creation and progress.
-
-## Approving Gated Tasks Remotely
-
-When autonomy mode is `gated`, tasks stop at `awaiting_approval`. You can approve directly from GitHub comments.
-
-1. **On the same issue thread, add an approval comment:**
-
-   ```
-   /approve
+   ```text
+   @agent repo=italnstallion789/predictiv
+   Add a health-check endpoint and update the tests.
    ```
 
-2. **Optional: approve a specific task ID explicitly:**
+3. The worker polls the control repository, normalizes the request, stores the task in PostgreSQL, and enqueues it through Redis.
+4. Track progress through:
+   - `GET /tasks`
+   - `GET /tasks/{task_id}`
+   - `GET /tasks/{task_id}/timeline`
+   - `GET /dashboard`
 
-   ```
-   /approve <task_id>
-   ```
+## Remote approval workflow
 
-   or:
+When `autonomy.mode` is `gated`, the run pauses at `awaiting_approval` after planning, proposal generation, review, security scan, and PR draft generation.
 
-   ```
-   /approve task=<task_id>
-   ```
+Approve from the same control-repository issue thread with either:
 
-3. **What happens next:**
-   - Poller sees the approval command.
-   - Matching task transitions from `awaiting_approval` to `ready`.
-   - Agent opens a draft PR in the target repository from a feature branch.
-   - Task transitions to `succeeded` when PR creation completes.
-   - You can verify via `GET /tasks` and task timeline endpoints.
+```text
+/approve
+```
 
-4. **Reject a task remotely:**
+or:
 
-   ```
-   /reject <task_id> reason here
-   ```
+```text
+/approve <task_id>
+```
 
-   or:
+Reject with either:
 
-   ```
-   /reject reason here
-   ```
+```text
+/reject reason here
+```
 
-   This marks the matching task as `cancelled` with rejection details in timeline metadata.
+or:
 
-## Branching Behavior
+```text
+/reject <task_id> reason here
+```
 
-- When code changes are made, the agent creates a new feature branch in the target repository (not in the develop/main branch).
-- The branch name is typically `agentic/<run_id>` or similar.
-- A pull request is then opened from the feature branch to the default branch (e.g., `main` or `master`).
-- This ensures all changes are reviewed and merged via PR, keeping the develop/main branch clean.
+After approval, the worker opens a draft PR in the target repository from an `agentic/<run>` branch.
 
-## Summary
-- Use issue/PR comments in your control repo to trigger agentic tasks.
-- Specify the target repo with `repo=...` or `/repo ...`.
-- The agent creates feature branches and PRs for all code changes.
-- Monitor progress via API or logs.
+## Chat control plane workflow
 
-## Operations Dashboard
+The app also supports remote intake from `http://localhost:8080/chat`.
 
-- Open `http://localhost:8080/dashboard` for a human-readable UI.
-- Dashboard data endpoint: `GET /dashboard/data`.
-- Dashboard shows, per task:
-   - request title/body and sender
-   - source and target repository
-   - current task status
-   - run id and run status
-   - PR draft title and opened PR link (when available)
-   - polling summary (mode and last poll timestamp)
+1. Open `/chat`.
+2. If `API_ADMIN_TOKEN` is configured, enter it when prompted by the UI.
+3. Create a session for an allowed target repository.
+4. Add one or more messages describing the work.
+5. In `gated` mode, set an approval issue number on the session or execution request.
+6. Execute the session to enqueue it as a normal task.
 
-## Required GitHub App Permissions
+Chat sessions are persisted in PostgreSQL and linked back to any tasks they create.
 
-For remote status updates and approval comments, your GitHub App must include:
+## What the current PR contains
 
-- Metadata: Read
-- Contents: Read & Write
-- Pull requests: Read & Write
-- Issues: Read & Write
+The current implementation does not write model-generated source edits into the target repository.
 
-For more details, see the README or API documentation.
+- The branch contains a run artifact at `.agentic/runs/<run_id>.md`
+- The draft PR title/body come from the pipeline output
+- The proposal, target files, review result, and test plan are visible through task/run metadata
+
+This means the system is currently strongest as a controlled planning, approval, and orchestration layer rather than a full patch-writing engine.
+
+## Operational endpoints
+
+- `GET /healthz`
+- `GET /readyz`
+- `GET /startup/self-check`
+- `GET /polling/status`
+- `GET /dashboard`
+- `GET /chat`
+
+## Validation commands
+
+- `make test-regression`
+- `make smoke`
+- `make qa`


### PR DESCRIPTION
## Summary
- align README, PRODUCT, and USAGE with the validated runtime behavior
- document the current chat, approval, and artifact-backed PR operating model
- clarify current scope and recommended next investments

## Validation
- make qa
- /healthz
- /readyz
- /startup/self-check
- /polling/status

## Notes
- no code-path changes in this PR
- this is the follow-up docs branch that was still pending after the develop merge