### PR TITLE
Fix GitHub approval PR creation in polling loop

### DIFF
--- a/src/agentic_coder/worker.py
+++ b/src/agentic_coder/worker.py
@@ -387,7 +387,7 @@ def build_approval_comment(
     )
 
 
-def create_pr_for_ready_task(
+async def create_pr_for_ready_task_async(
     *,
     repo: TaskRepository,
     task_id: str,
@@ -482,7 +482,7 @@ def create_pr_for_ready_task(
     )
 
     try:
-        result = asyncio.run(_open_pr())
+        result = await _open_pr()
     except Exception as exc:
         repo.append_run_event(
             run_id,
@@ -526,6 +526,30 @@ def create_pr_for_ready_task(
     )
     repo.complete_run(run_id, status="succeeded")
     return True
+
+
+def create_pr_for_ready_task(
+    *,
+    repo: TaskRepository,
+    task_id: str,
+    requested_by: str,
+    policy: object,
+) -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            create_pr_for_ready_task_async(
+                repo=repo,
+                task_id=task_id,
+                requested_by=requested_by,
+                policy=policy,
+            )
+        )
+    raise RuntimeError(
+        "create_pr_for_ready_task cannot run inside an active event loop; "
+        "use create_pr_for_ready_task_async instead"
+    )
 
 
 def publish_approval_request_comment(
@@ -605,7 +629,7 @@ def _status_label(status: str) -> str:
     return f"agentic:{normalized}"
 
 
-def publish_issue_status_update(
+async def publish_issue_status_update_for_task_async(
     *,
     task_payload: dict[str, object],
     status: str,
@@ -639,30 +663,35 @@ def publish_issue_status_update(
         settings.github_private_key,
         api_base_url=settings.github_api_base_url,
     )
+    await publish_issue_status_update_async(
+        github=github,
+        source_repository=source_repository,
+        issue_number=issue_number,
+        installation_id=installation_id,
+        status=status,
+        body=body,
+    )
+
+
+def publish_issue_status_update(
+    *,
+    task_payload: dict[str, object],
+    status: str,
+    summary: str,
+    details: dict[str, object] | None = None,
+) -> None:
+    publish_coro = publish_issue_status_update_for_task_async(
+        task_payload=task_payload,
+        status=status,
+        summary=summary,
+        details=details,
+    )
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        asyncio.run(
-            publish_issue_status_update_async(
-                github=github,
-                source_repository=source_repository,
-                issue_number=issue_number,
-                installation_id=installation_id,
-                status=status,
-                body=body,
-            )
-        )
+        asyncio.run(publish_coro)
     else:
-        loop.create_task(
-            publish_issue_status_update_async(
-                github=github,
-                source_repository=source_repository,
-                issue_number=issue_number,
-                installation_id=installation_id,
-                status=status,
-                body=body,
-            )
-        )
+        loop.create_task(publish_coro)
 
 
 async def publish_issue_status_update_async(
@@ -842,14 +871,14 @@ def poll_control_repository_once(
                         )
                         approved += 1
                         try:
-                            if create_pr_for_ready_task(
+                            if await create_pr_for_ready_task_async(
                                 repo=repo,
                                 task_id=approved_task_id,
                                 requested_by=normalized.sender,
                                 policy=policy,
                             ):
                                 prs_created += 1
-                                publish_issue_status_update(
+                                await publish_issue_status_update_for_task_async(
                                     task_payload=task.payload,
                                     status="pr_opened",
                                     summary="Approval received and draft PR opened",
@@ -859,7 +888,7 @@ def poll_control_repository_once(
                                     },
                                 )
                             else:
-                                publish_issue_status_update(
+                                await publish_issue_status_update_for_task_async(
                                     task_payload=task.payload,
                                     status="failed",
                                     summary="Approval received but PR creation failed",
@@ -895,7 +924,7 @@ def poll_control_repository_once(
                         )
                         approved += 1
                         try:
-                            if create_pr_for_ready_task(
+                            if await create_pr_for_ready_task_async(
                                 repo=repo,
                                 task_id=latest_task_id,
                                 requested_by=normalized.sender,
@@ -903,7 +932,7 @@ def poll_control_repository_once(
                             ):
                                 prs_created += 1
                                 if latest_task is not None:
-                                    publish_issue_status_update(
+                                    await publish_issue_status_update_for_task_async(
                                         task_payload=latest_task.payload,
                                         status="pr_opened",
                                         summary="Approval received and draft PR opened",
@@ -911,10 +940,10 @@ def poll_control_repository_once(
                                             "task_id": latest_task_id,
                                             "approved_by": normalized.sender,
                                         },
-                                    )
+                                )
                             else:
                                 if latest_task is not None:
-                                    publish_issue_status_update(
+                                    await publish_issue_status_update_for_task_async(
                                         task_payload=latest_task.payload,
                                         status="failed",
                                         summary="Approval received but PR creation failed",
@@ -952,7 +981,7 @@ def poll_control_repository_once(
                 },
             )
             queue.enqueue(task.task_id)
-            publish_issue_status_update(
+            await publish_issue_status_update_for_task_async(
                 task_payload=task.payload,
                 status="queued",
                 summary="Task request received and queued",

--- a/src/agentic_coder/worker.py
+++ b/src/agentic_coder/worker.py
@@ -839,7 +839,7 @@ def poll_control_repository_once(
                         },
                     )
                     if target_task is not None:
-                        publish_issue_status_update(
+                        await publish_issue_status_update_for_task_async(
                             task_payload=target_task.payload,
                             status="rejected",
                             summary="Task was rejected from GitHub comment",

--- a/tests/test_worker_polling.py
+++ b/tests/test_worker_polling.py
@@ -1,6 +1,11 @@
+from datetime import UTC, datetime
+
+from agentic_coder import worker as worker_module
 from agentic_coder.domain.tasks import TaskRecord, TaskState
+from agentic_coder.github_app.models import NormalizedGithubTask
 from agentic_coder.worker import (
     build_approval_comment,
+    create_pr_for_ready_task,
     extract_approval_task_id,
     extract_rejection_reason,
     extract_rejection_task_id,
@@ -148,3 +153,201 @@ def test_build_approval_comment_contains_summary_and_commands() -> None:
     assert "Implement cache layer" in body
     assert "src/cache.py" in body
     assert "/approve 123e4567-e89b-12d3-a456-426614174000" in body
+
+
+def test_create_pr_for_ready_task_sync_wrapper_uses_async_helper(monkeypatch) -> None:
+    recorded: list[dict[str, object]] = []
+
+    async def _fake_create_pr_for_ready_task_async(**kwargs) -> bool:  # noqa: ANN003
+        recorded.append(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        worker_module,
+        "create_pr_for_ready_task_async",
+        _fake_create_pr_for_ready_task_async,
+    )
+
+    assert (
+        create_pr_for_ready_task(
+            repo=object(),  # type: ignore[arg-type]
+            task_id="task-1",
+            requested_by="alex",
+            policy=object(),
+        )
+        is True
+    )
+    assert recorded[0]["task_id"] == "task-1"
+    assert recorded[0]["requested_by"] == "alex"
+
+
+class _PollingApprovalRepo:
+    def __init__(self) -> None:
+        now = datetime.now(UTC)
+        self.task = TaskRecord(
+            task_id="123e4567-e89b-12d3-a456-426614174000",
+            title="Queued task",
+            payload={
+                "source_repository": "acme/control",
+                "repository": "acme/predictiv",
+                "issue_number": 42,
+                "installation_id": 77,
+                "source_installation_id": 77,
+                "target_installation_id": 88,
+            },
+            state=TaskState.AWAITING_APPROVAL,
+            created_at=now,
+            updated_at=now,
+        )
+        self.cursor: dict[str, object] | None = None
+        self.transitions: list[tuple[str, str | None]] = []
+
+    def get_poll_cursor(self, cursor_key: str) -> dict[str, object] | None:
+        _ = cursor_key
+        return None
+
+    def upsert_poll_cursor(self, cursor_key: str, cursor: dict[str, object]) -> None:
+        _ = cursor_key
+        self.cursor = cursor
+
+    def get_by_id(self, task_id: str) -> TaskRecord | None:
+        if task_id != self.task.task_id:
+            return None
+        return self.task
+
+    def update_state(self, task_id: str, state: TaskState, **kwargs) -> TaskRecord | None:  # noqa: ANN003
+        if task_id != self.task.task_id:
+            return None
+        self.task.state = state
+        self.transitions.append((state.value, kwargs.get("reason")))
+        return self.task
+
+
+class _PollingQueue:
+    def enqueue(self, task_id: str) -> None:
+        _ = task_id
+
+
+class _PollingPolicy:
+    class system:  # noqa: N801
+        control_repository = "acme/control"
+        allow_any_target_repository = False
+        allowed_target_repositories = ["acme/predictiv", "predictiv"]
+
+    class trigger:  # noqa: N801
+        max_items_per_poll = 50
+
+
+class _PollingGithub:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        _ = args, kwargs
+
+    async def get_repository_installation(self, repository: str) -> dict[str, object]:
+        _ = repository
+        return {"id": 77}
+
+    async def create_installation_token(self, installation_id: int) -> str:
+        _ = installation_id
+        return "token"
+
+    async def list_issue_comments_since(
+        self,
+        repository: str,
+        installation_token: str,
+        *,
+        since: str | None,
+        per_page: int = 50,
+    ) -> list[dict[str, object]]:
+        _ = repository, installation_token, since, per_page
+        return [
+            {
+                "id": 501,
+                "updated_at": "2026-03-14T12:00:00Z",
+                "body": "/approve 123e4567-e89b-12d3-a456-426614174000",
+                "issue_url": "https://api.github.com/repos/acme/control/issues/42",
+                "user": {"login": "alex", "type": "User"},
+            }
+        ]
+
+    def normalize_polled_issue_comment(
+        self,
+        source_repository: str,
+        installation_id: int,
+        comment: dict[str, object],
+    ) -> NormalizedGithubTask:
+        _ = installation_id, comment
+        return NormalizedGithubTask(
+            event_name="issue_comment",
+            source_repository=source_repository,
+            target_repository="acme/predictiv",
+            installation_id=77,
+            title="Issue #42 comment from alex",
+            body="/approve 123e4567-e89b-12d3-a456-426614174000",
+            issue_number=42,
+            sender="alex",
+            raw_event={"polling": True},
+        )
+
+
+def test_poll_control_repository_once_uses_async_helpers_for_approval_flow(monkeypatch) -> None:
+    repo = _PollingApprovalRepo()
+    pr_calls: list[dict[str, object]] = []
+    status_calls: list[dict[str, object]] = []
+
+    async def _fake_create_pr_for_ready_task_async(**kwargs) -> bool:  # noqa: ANN003
+        pr_calls.append(kwargs)
+        return True
+
+    async def _fake_publish_issue_status_update_for_task_async(**kwargs) -> None:  # noqa: ANN003
+        status_calls.append(kwargs)
+
+    def _sync_create_pr_should_not_run(**kwargs) -> bool:  # noqa: ANN003
+        raise AssertionError("sync PR helper should not be used inside polling loop")
+
+    def _sync_status_should_not_run(**kwargs) -> None:  # noqa: ANN003
+        raise AssertionError("sync status helper should not be used inside polling loop")
+
+    monkeypatch.setattr(worker_module, "GitHubAppService", _PollingGithub)
+    monkeypatch.setattr(
+        worker_module,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "github_app_id": "1",
+                "github_private_key": "test-key",
+                "github_api_base_url": "https://api.github.com",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "create_pr_for_ready_task_async",
+        _fake_create_pr_for_ready_task_async,
+    )
+    monkeypatch.setattr(worker_module, "create_pr_for_ready_task", _sync_create_pr_should_not_run)
+    monkeypatch.setattr(
+        worker_module,
+        "publish_issue_status_update_for_task_async",
+        _fake_publish_issue_status_update_for_task_async,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "publish_issue_status_update",
+        _sync_status_should_not_run,
+    )
+
+    created = worker_module.poll_control_repository_once(
+        _PollingPolicy(),
+        repo,  # type: ignore[arg-type]
+        _PollingQueue(),  # type: ignore[arg-type]
+    )
+
+    assert created == 0
+    assert repo.transitions == [("ready", "github_comment_approved")]
+    assert pr_calls[0]["task_id"] == repo.task.task_id
+    assert status_calls[0]["status"] == "pr_opened"
+    assert repo.cursor is not None
+    assert repo.cursor["last_approved_count"] == 1
+    assert repo.cursor["last_prs_created_count"] == 1

--- a/tests/test_worker_polling.py
+++ b/tests/test_worker_polling.py
@@ -351,3 +351,92 @@ def test_poll_control_repository_once_uses_async_helpers_for_approval_flow(monke
     assert repo.cursor is not None
     assert repo.cursor["last_approved_count"] == 1
     assert repo.cursor["last_prs_created_count"] == 1
+
+
+def test_poll_control_repository_once_uses_async_status_helper_for_rejections(
+    monkeypatch,
+) -> None:
+    repo = _PollingApprovalRepo()
+    status_calls: list[dict[str, object]] = []
+
+    class _RejectingGithub(_PollingGithub):
+        async def list_issue_comments_since(
+            self,
+            repository: str,
+            installation_token: str,
+            *,
+            since: str | None,
+            per_page: int = 50,
+        ) -> list[dict[str, object]]:
+            _ = repository, installation_token, since, per_page
+            return [
+                {
+                    "id": 502,
+                    "updated_at": "2026-03-14T12:01:00Z",
+                    "body": "/reject 123e4567-e89b-12d3-a456-426614174000 too risky",
+                    "issue_url": "https://api.github.com/repos/acme/control/issues/42",
+                    "user": {"login": "alex", "type": "User"},
+                }
+            ]
+
+        def normalize_polled_issue_comment(
+            self,
+            source_repository: str,
+            installation_id: int,
+            comment: dict[str, object],
+        ) -> NormalizedGithubTask:
+            _ = installation_id, comment
+            return NormalizedGithubTask(
+                event_name="issue_comment",
+                source_repository=source_repository,
+                target_repository="acme/predictiv",
+                installation_id=77,
+                title="Issue #42 comment from alex",
+                body="/reject 123e4567-e89b-12d3-a456-426614174000 too risky",
+                issue_number=42,
+                sender="alex",
+                raw_event={"polling": True},
+            )
+
+    async def _fake_publish_issue_status_update_for_task_async(**kwargs) -> None:  # noqa: ANN003
+        status_calls.append(kwargs)
+
+    def _sync_status_should_not_run(**kwargs) -> None:  # noqa: ANN003
+        raise AssertionError("sync status helper should not be used inside polling loop")
+
+    monkeypatch.setattr(worker_module, "GitHubAppService", _RejectingGithub)
+    monkeypatch.setattr(
+        worker_module,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "github_app_id": "1",
+                "github_private_key": "test-key",
+                "github_api_base_url": "https://api.github.com",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "publish_issue_status_update_for_task_async",
+        _fake_publish_issue_status_update_for_task_async,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "publish_issue_status_update",
+        _sync_status_should_not_run,
+    )
+
+    created = worker_module.poll_control_repository_once(
+        _PollingPolicy(),
+        repo,  # type: ignore[arg-type]
+        _PollingQueue(),  # type: ignore[arg-type]
+    )
+
+    assert created == 0
+    assert repo.transitions == [("cancelled", "github_comment_rejected")]
+    assert status_calls[0]["status"] == "rejected"
+    assert repo.cursor is not None
+    assert repo.cursor["last_rejected_count"] == 1


### PR DESCRIPTION
## Summary
- move approval-triggered PR creation onto an async-safe helper and keep a sync wrapper for non-async call sites
- await polling-originated GitHub status updates so queued and approval comments are actually published before the poll loop exits
- add regression coverage for the polling approval path and the sync wrapper behavior

## Validation
- ruff check --no-cache src tests --select I,F,E
- PYTEST_ADDOPTS='-p no:cacheprovider' pytest tests -q
- python scripts/smoke_test.py --base-url http://localhost:8080 --target-repository predictiv --wait-seconds 180
- live GitHub validation on issue #2: queued comment, approval request, /approve processing, pr_opened status comment, and draft PR predictiv#12

## Notes
- PR predictiv#12 was opened as a draft during live validation of the approval path