### PR TITLE
Apply proposed file changes before opening draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,17 @@ jobs:
       - name: Start stack
         run: docker compose up --build -d postgres redis api
 
+      - name: Wait for Postgres
+        run: |
+          for attempt in $(seq 1 30); do
+            if docker compose exec -T postgres pg_isready -U agentic_coder -d agentic_coder; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker compose logs --no-color --tail=200 postgres
+          exit 1
+
       - name: Apply migrations
         run: docker compose run --rm api python -m alembic upgrade head
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ Agentic Coder is a local-first, GitHub-native autonomous AI development platform
 
 The platform is designed around a human-in-the-loop approval model: in `gated` mode (default), every proposed change waits for explicit sign-off via a GitHub comment before a PR is opened. In `autonomous` mode, the agent acts end-to-end without pausing.
 
-Current implementation note: the PR branch currently contains a run artifact (`.agentic/runs/<run_id>.md`) plus PR draft metadata. The pipeline does not yet write source-code edits into the target repository.
+Current implementation note: the PR branch always contains a run artifact (`.agentic/runs/<run_id>.md`). When the coding proposal includes concrete file contents, those files are also written into the target-repository branch before the PR opens. If no concrete file contents are available, the PR remains artifact-only.
 
 ---
 
@@ -53,7 +53,7 @@ TaskPipeline
 [autonomous mode] Proceed immediately
       │
       ▼
-Create branch → commit artifact → open draft PR in target repo
+Create branch → commit proposed file changes + artifact → open draft PR in target repo
       │
       ▼
 Post status update comment on source issue
@@ -63,8 +63,8 @@ Post status update comment on source issue
 
 - The pipeline generates a `PatchProposal`, review result, security result, test plan, and PR draft
 - Approval and status comments are posted back to the control-repository issue when issue context is present
-- Target-repository PRs are currently artifact-backed and are intended as a controlled handoff / approval surface
-- Direct file patch application in the target repository is not implemented yet
+- Target-repository PRs always contain a run artifact and may also contain model-proposed file changes
+- Direct patch application currently depends on the coding agent returning full file contents for files already present in retrieved context
 
 ---
 
@@ -126,8 +126,8 @@ All agents receive the same `ModelProvider` instance resolved at pipeline init. 
 
 ### CodingAgent
 - **Input:** `PlanResult` + context documents + repository name
-- **Output:** `PatchProposal` — summary of changes + list of target file paths
-- **Model prompt:** produces JSON `{summary, target_files}` constrained to files present in context
+- **Output:** `PatchProposal` — summary of changes + list of target file paths + optional full-file updates
+- **Model prompt:** produces JSON `{summary, target_files, file_changes}` constrained to files present in context
 
 ### ReviewerAgent
 - **Input:** `PatchProposal`
@@ -312,7 +312,7 @@ In `gated` autonomy mode, chat execution requires a GitHub approval issue number
 - Set `approval_issue_number` on session create, or pass it during execute
 - Worker posts approval-request/status comments to the control repository issue
 - `/approve` and `/reject` comments continue to drive transitions and PR creation
-- The resulting PR is still artifact-backed until direct patch application is implemented
+- The resulting PR always contains a run artifact and may also contain model-proposed file updates when available
 
 ### Installation Context Separation
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ The current implementation includes:
 
 The pipeline currently plans, retrieves context, reviews, generates validation commands, and drafts PR metadata.
 
-- The current PR flow is artifact-backed: it creates a target-repo branch, commits `.agentic/runs/<run_id>.md`, and opens a draft PR
-- It does not yet apply generated source-code edits into the target repository
-- That limitation should be kept in mind when operating the system or evaluating run results
+- The current PR flow always creates a target-repo branch, commits `.agentic/runs/<run_id>.md`, and opens a draft PR
+- When the coding proposal includes concrete file contents, those files are written into the PR branch before the PR opens
+- If the proposal does not include concrete file contents, the PR remains artifact-only
+- Patch application is therefore present, but it is still limited by proposal quality and the current context window
 
 ## Development workflow
 
@@ -89,6 +90,7 @@ The API supports creating a draft PR from an existing run timeline:
 - body: `{"installation_id": <int>, "branch_name": "agentic/<run>", "draft": true}`
 
 This flow uses GitHub App installation token exchange, resolves the repository default branch, creates the head branch, commits the run artifact, and opens a draft PR using run-generated PR draft metadata.
+When the run includes concrete `file_changes`, those files are committed to the branch before the run artifact is written.
 
 ### Control repo vs target repos
 
@@ -211,7 +213,7 @@ A host Python environment is optional and only needed if container-based develop
 
 ## Recommended next investments
 
-- Add real patch application so target-repo PRs contain source edits instead of only run artifacts
+- Improve patch fidelity so the coding agent can reliably produce complete file updates for more than the current narrow context window
 - Execute generated validation commands in the sandbox executor before PR open
 - Reduce worker idle-log noise or make polling log verbosity configurable
 - Strengthen retrieval and knowledge-graph quality beyond the current `.py`-centric heuristics

--- a/USAGE.md
+++ b/USAGE.md
@@ -62,13 +62,14 @@ Chat sessions are persisted in PostgreSQL and linked back to any tasks they crea
 
 ## What the current PR contains
 
-The current implementation does not write model-generated source edits into the target repository.
+The current implementation always writes a run artifact and may also write model-generated source edits into the target repository.
 
 - The branch contains a run artifact at `.agentic/runs/<run_id>.md`
+- If the coding proposal includes concrete `file_changes`, those files are committed into the PR branch before the artifact
 - The draft PR title/body come from the pipeline output
 - The proposal, target files, review result, and test plan are visible through task/run metadata
 
-This means the system is currently strongest as a controlled planning, approval, and orchestration layer rather than a full patch-writing engine.
+This means the system can now open real file-changing PRs, but patch quality still depends on the coding proposal producing complete file contents from the retrieved context.
 
 ## Operational endpoints
 

--- a/src/agentic_coder/agents/coder.py
+++ b/src/agentic_coder/agents/coder.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from agentic_coder.agents.planner import PlanResult
 from agentic_coder.models.providers import ChatMessage, ModelProvider
+from agentic_coder.pull_requests import ProposedFileChange
 from agentic_coder.retrieval.service import RetrievalDocument
 
 
@@ -11,6 +12,7 @@ from agentic_coder.retrieval.service import RetrievalDocument
 class PatchProposal:
     summary: str
     target_files: list[str]
+    file_changes: list[ProposedFileChange] = field(default_factory=list)
 
 
 class CodingAgent:
@@ -41,7 +43,7 @@ class CodingAgent:
             f"Objective: {plan.objective}. "
             f"Prepared implementation path across {len(target_files)} candidate files."
         )
-        return PatchProposal(summary=summary, target_files=target_files)
+        return PatchProposal(summary=summary, target_files=target_files, file_changes=[])
 
     def _propose_with_model(
         self,
@@ -57,11 +59,16 @@ class CodingAgent:
         steps_text = "\n".join(f"  {i + 1}. {step}" for i, step in enumerate(plan.steps))
         prompt = (
             "You are an expert software engineer. Given a task plan and relevant repository files, "
-            "identify which files need to be changed and describe the implementation approach.\n"
+            "identify which files need to be changed and, when safe, provide the full updated "
+            "contents for those files.\n"
             "Only reference file paths that exist in the provided file list.\n"
             "Return ONLY compact JSON with keys:\n"
             "  - summary (string): concise description of what changes will be made\n"
-            "  - target_files (array of strings): relative file paths that need modification\n\n"
+            "  - target_files (array of strings): relative file paths that need modification\n"
+            "  - file_changes (array of objects): optional full-file updates with keys path and "
+            "content\n"
+            "If you cannot safely rewrite a file from the provided context, omit it from "
+            "file_changes.\n\n"
             f"Repository: {repository or 'unknown'}\n"
             f"Objective: {plan.objective}\n"
             f"Steps:\n{steps_text}\n\n"
@@ -79,4 +86,16 @@ class CodingAgent:
         summary = str(parsed.get("summary") or plan.objective)
         files = parsed.get("target_files") or []
         target_files = [str(f) for f in files if str(f).strip()]
-        return PatchProposal(summary=summary, target_files=target_files)
+        file_changes = [
+            ProposedFileChange(
+                path=str(item.get("path") or "").strip(),
+                content=str(item.get("content") or ""),
+            )
+            for item in (parsed.get("file_changes") or [])
+            if isinstance(item, dict) and str(item.get("path") or "").strip()
+        ]
+        return PatchProposal(
+            summary=summary,
+            target_files=target_files,
+            file_changes=file_changes,
+        )

--- a/src/agentic_coder/api/main.py
+++ b/src/agentic_coder/api/main.py
@@ -17,6 +17,7 @@ from agentic_coder.domain.tasks import TaskState
 from agentic_coder.github_app.service import GitHubAppService, WebhookVerifier
 from agentic_coder.logging import configure_logging
 from agentic_coder.policy.loader import PolicyLoader, resolve_policy_path
+from agentic_coder.pull_requests import apply_pull_request_changes, extract_proposed_file_changes
 from agentic_coder.queue.redis_queue import RedisTaskQueue
 
 configure_logging()
@@ -1218,6 +1219,7 @@ async def create_pull_request_from_run(
     if pr_event is None:
         raise HTTPException(status_code=400, detail="PR draft metadata not found for run")
     pr_body = str(pr_event["payload"].get("body") or "Automated change set")
+    file_changes = extract_proposed_file_changes(events)
 
     settings = get_settings()
     github = GitHubAppService(
@@ -1231,23 +1233,17 @@ async def create_pull_request_from_run(
     base_sha = await github.get_branch_head_sha(repository, base_branch, token)
     await github.create_branch(repository, request_body.branch_name, base_sha, token)
 
-    artifact_path = f".agentic/runs/{run_id}.md"
-    artifact_content = (
-        f"# Run {run_id}\n\n"
-        f"- Repository: {repository}\n"
-        f"- Task ID: {task.task_id}\n"
-        f"- Run status: {run['status']}\n\n"
-        f"## PR Draft\n\n"
-        f"### Title\n{pr_title}\n\n"
-        f"### Body\n{pr_body}\n"
-    )
-    commit_result = await github.upsert_file(
-        repository,
-        token,
+    applied = await apply_pull_request_changes(
+        github=github,
+        repository=repository,
+        installation_token=token,
         branch=request_body.branch_name,
-        path=artifact_path,
-        message=f"agentic: add run artifact {run_id}",
-        content=artifact_content,
+        run_id=run_id,
+        task_id=task.task_id,
+        requested_by="manual_api",
+        pr_title=pr_title,
+        pr_body=pr_body,
+        file_changes=file_changes,
     )
 
     pull_request = await github.create_pull_request(
@@ -1263,9 +1259,10 @@ async def create_pull_request_from_run(
     return {
         "repository": repository,
         "run_id": run_id,
+        "changed_files": applied.changed_files,
         "artifact": {
-            "path": artifact_path,
-            "commit_sha": ((commit_result.get("commit") or {}).get("sha")),
+            "path": applied.artifact_path,
+            "commit_sha": applied.artifact_commit_sha,
         },
         "pull_request": {
             "id": pull_request.get("id"),

--- a/src/agentic_coder/github_app/service.py
+++ b/src/agentic_coder/github_app/service.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import re
 import time
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from datetime import UTC, datetime
 from typing import Any
 
@@ -314,6 +314,18 @@ class GitHubAppService:
         ref: str,
         installation_token: str,
     ) -> str | None:
+        file_info = await self.get_file(repository, path, ref, installation_token)
+        if file_info is None:
+            return None
+        return str(file_info.get("sha") or "") or None
+
+    async def get_file(
+        self,
+        repository: str,
+        path: str,
+        ref: str,
+        installation_token: str,
+    ) -> dict[str, Any] | None:
         url = f"{self.api_base_url}/repos/{repository}/contents/{path}"
         headers = self._installation_headers(installation_token)
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -321,7 +333,11 @@ class GitHubAppService:
         if response.status_code == 404:
             return None
         response.raise_for_status()
-        return response.json().get("sha")
+        payload: dict[str, Any] = response.json()
+        encoded_content = str(payload.get("content") or "")
+        if payload.get("encoding") == "base64" and encoded_content:
+            payload["decoded_content"] = b64decode(encoded_content).decode("utf-8")
+        return payload
 
     async def upsert_file(
         self,
@@ -333,7 +349,15 @@ class GitHubAppService:
         message: str,
         content: str,
     ) -> dict[str, Any]:
-        existing_sha = await self.get_file_sha(repository, path, branch, installation_token)
+        existing_file = await self.get_file(repository, path, branch, installation_token)
+        existing_sha = (existing_file or {}).get("sha")
+        existing_content = (existing_file or {}).get("decoded_content")
+        if existing_content == content:
+            return {
+                "commit": {},
+                "content": {"path": path},
+                "skipped": True,
+            }
         encoded_content = b64encode(content.encode("utf-8")).decode("utf-8")
         url = f"{self.api_base_url}/repos/{repository}/contents/{path}"
         headers = self._installation_headers(installation_token)

--- a/src/agentic_coder/pull_requests.py
+++ b/src/agentic_coder/pull_requests.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from agentic_coder.github_app.service import GitHubAppService
+
+
+@dataclass(slots=True)
+class ProposedFileChange:
+    path: str
+    content: str
+
+
+@dataclass(slots=True)
+class AppliedPullRequestChanges:
+    changed_files: list[str]
+    artifact_path: str
+    artifact_commit_sha: str | None
+
+
+def extract_proposed_file_changes(events: list[dict[str, object]]) -> list[ProposedFileChange]:
+    proposal_event = next(
+        (event for event in events if event.get("event_type") == "proposal_generated"),
+        None,
+    )
+    payload = dict((proposal_event or {}).get("payload") or {})
+    target_files = {
+        str(path).strip()
+        for path in (payload.get("target_files") or [])
+        if str(path).strip()
+    }
+    raw_changes = payload.get("file_changes") or []
+    changes: list[ProposedFileChange] = []
+    seen_paths: set[str] = set()
+
+    if not isinstance(raw_changes, list):
+        return changes
+
+    for item in raw_changes:
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path") or "").strip()
+        content = str(item.get("content") or "")
+        if not path or path in seen_paths:
+            continue
+        if not is_safe_repo_relative_path(path):
+            continue
+        if target_files and path not in target_files:
+            continue
+        seen_paths.add(path)
+        changes.append(ProposedFileChange(path=path, content=content))
+
+    return changes
+
+
+def is_safe_repo_relative_path(path: str) -> bool:
+    if not path or path.startswith("/") or path.startswith(".agentic/"):
+        return False
+    normalized = PurePosixPath(path)
+    if normalized.is_absolute():
+        return False
+    parts = normalized.parts
+    if not parts:
+        return False
+    return all(part not in ("", ".", "..") for part in parts)
+
+
+def build_run_artifact_content(
+    *,
+    run_id: str,
+    repository: str,
+    task_id: str,
+    requested_by: str,
+    pr_title: str,
+    pr_body: str,
+    changed_files: list[str],
+) -> str:
+    changed_files_text = "\n".join(f"- {path}" for path in changed_files) or "- (artifact only)"
+    return (
+        f"# Run {run_id}\n\n"
+        f"- Repository: {repository}\n"
+        f"- Task ID: {task_id}\n"
+        "- PR triggered by Agentic workflow\n"
+        f"- Requested by: {requested_by}\n\n"
+        "## Applied File Changes\n"
+        f"{changed_files_text}\n\n"
+        f"## PR Title\n{pr_title}\n\n"
+        f"## PR Body\n{pr_body}\n"
+    )
+
+
+async def apply_pull_request_changes(
+    *,
+    github: GitHubAppService,
+    repository: str,
+    installation_token: str,
+    branch: str,
+    run_id: str,
+    task_id: str,
+    requested_by: str,
+    pr_title: str,
+    pr_body: str,
+    file_changes: list[ProposedFileChange],
+) -> AppliedPullRequestChanges:
+    changed_files: list[str] = []
+
+    for change in file_changes:
+        commit_result = await github.upsert_file(
+            repository,
+            installation_token,
+            branch=branch,
+            path=change.path,
+            message=f"agentic: update {change.path} for run {run_id}",
+            content=change.content,
+        )
+        if not commit_result.get("skipped"):
+            changed_files.append(change.path)
+
+    artifact_path = f".agentic/runs/{run_id}.md"
+    artifact_content = build_run_artifact_content(
+        run_id=run_id,
+        repository=repository,
+        task_id=task_id,
+        requested_by=requested_by,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        changed_files=changed_files,
+    )
+    artifact_result = await github.upsert_file(
+        repository,
+        installation_token,
+        branch=branch,
+        path=artifact_path,
+        message=f"agentic: add run artifact {run_id}",
+        content=artifact_content,
+    )
+
+    return AppliedPullRequestChanges(
+        changed_files=changed_files,
+        artifact_path=artifact_path,
+        artifact_commit_sha=((artifact_result.get("commit") or {}).get("sha")),
+    )

--- a/src/agentic_coder/worker.py
+++ b/src/agentic_coder/worker.py
@@ -14,6 +14,7 @@ from agentic_coder.github_app.service import GitHubAppService
 from agentic_coder.logging import configure_logging
 from agentic_coder.orchestration.pipeline import TaskPipeline
 from agentic_coder.policy.loader import PolicyLoader
+from agentic_coder.pull_requests import apply_pull_request_changes, extract_proposed_file_changes
 from agentic_coder.queue.redis_queue import RedisTaskQueue
 
 configure_logging()
@@ -171,6 +172,10 @@ def process_task(
             {
                 "summary": result.proposal.summary,
                 "target_files": result.proposal.target_files,
+                "file_changes": [
+                    {"path": change.path, "content": change.content}
+                    for change in result.proposal.file_changes
+                ],
             },
         )
         repo.append_run_event(
@@ -422,6 +427,7 @@ async def create_pr_for_ready_task_async(
     pr_title = str((run.get("metadata") or {}).get("pr_title") or task.title)
     pr_body = str(pr_event["payload"].get("body") or "Automated change set")
     branch_name = f"agentic/{run_id[:8]}"
+    file_changes = extract_proposed_file_changes(events)
 
     settings = get_settings()
     if not settings.github_app_id or not settings.github_private_key:
@@ -439,23 +445,17 @@ async def create_pr_for_ready_task_async(
         base_sha = await github.get_branch_head_sha(repository, base_branch, token)
         await github.create_branch(repository, branch_name, base_sha, token)
 
-        artifact_path = f".agentic/runs/{run_id}.md"
-        artifact_content = (
-            f"# Run {run_id}\n\n"
-            f"- Repository: {repository}\n"
-            f"- Task ID: {task.task_id}\n"
-            "- PR triggered by Agentic workflow\n"
-            f"- Requested by: {requested_by}\n\n"
-            f"## PR Title\n{pr_title}\n\n"
-            f"## PR Body\n{pr_body}\n"
-        )
-        commit_result = await github.upsert_file(
-            repository,
-            token,
+        applied = await apply_pull_request_changes(
+            github=github,
+            repository=repository,
+            installation_token=token,
             branch=branch_name,
-            path=artifact_path,
-            message=f"agentic: add run artifact {run_id}",
-            content=artifact_content,
+            run_id=run_id,
+            task_id=task.task_id,
+            requested_by=requested_by,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            file_changes=file_changes,
         )
         pull_request = await github.create_pull_request(
             repository,
@@ -470,7 +470,9 @@ async def create_pr_for_ready_task_async(
             "pull_request": pull_request,
             "branch_name": branch_name,
             "base_branch": base_branch,
-            "commit_sha": ((commit_result.get("commit") or {}).get("sha") or ""),
+            "artifact_path": applied.artifact_path,
+            "artifact_commit_sha": applied.artifact_commit_sha or "",
+            "changed_files": applied.changed_files,
         }
 
     repo.update_state(
@@ -510,7 +512,9 @@ async def create_pr_for_ready_task_async(
             "base_branch": result.get("base_branch"),
             "pull_request_number": pull_request.get("number"),
             "pull_request_url": pull_request.get("html_url"),
-            "commit_sha": result.get("commit_sha"),
+            "artifact_path": result.get("artifact_path"),
+            "artifact_commit_sha": result.get("artifact_commit_sha"),
+            "changed_files": result.get("changed_files"),
         },
     )
     repo.update_state(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -182,6 +182,22 @@ class _TimelineRepo:
             return []
         return [
             {
+                "event_id": "evt-0",
+                "run_id": "run-1",
+                "event_type": "proposal_generated",
+                "payload": {
+                    "summary": "Implement cache",
+                    "target_files": ["src/cache.py"],
+                    "file_changes": [
+                        {
+                            "path": "src/cache.py",
+                            "content": "def cache():\n    return True\n",
+                        }
+                    ],
+                },
+                "created_at": datetime.now(UTC),
+            },
+            {
                 "event_id": "evt-1",
                 "run_id": "run-1",
                 "event_type": "plan_created",
@@ -253,10 +269,12 @@ def test_run_replay_endpoint(monkeypatch) -> None:
     assert data["run"]["metadata"]["objective"] == "Implement cache"
     assert len(data["timeline"]) == 1
     assert len(data["events"]) >= 2
-    assert data["events"][0]["event_type"] == "plan_created"
+    assert "plan_created" in [event["event_type"] for event in data["events"]]
 
 
 class _FakeGithubService:
+    written_paths: list[str] = []
+
     def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         self.created: list[tuple[str, str]] = []
 
@@ -297,6 +315,7 @@ class _FakeGithubService:
         content: str,
     ) -> dict[str, object]:
         _ = repository, installation_token, branch, message, content
+        self.__class__.written_paths.append(path)
         return {"commit": {"sha": "commit123"}, "content": {"path": path}}
 
     async def create_pull_request(
@@ -323,6 +342,7 @@ class _FakeGithubService:
 def test_create_pull_request_from_run(monkeypatch) -> None:
     from agentic_coder.api import main
 
+    _FakeGithubService.written_paths = []
     monkeypatch.setattr(main, "TaskRepository", _TimelineRepo)
     monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
     monkeypatch.setattr(main, "GitHubAppService", _FakeGithubService)
@@ -336,9 +356,11 @@ def test_create_pull_request_from_run(monkeypatch) -> None:
     data = response.json()
     assert data["run_id"] == "run-1"
     assert data["repository"] == "acme/predictiv"
+    assert data["changed_files"] == ["src/cache.py"]
     assert data["artifact"]["path"] == ".agentic/runs/run-1.md"
     assert data["artifact"]["commit_sha"] == "commit123"
     assert data["pull_request"]["number"] == 7
+    assert _FakeGithubService.written_paths == ["src/cache.py", ".agentic/runs/run-1.md"]
 
 
 def test_get_startup_self_check_endpoint() -> None:

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -1,0 +1,33 @@
+from agentic_coder.agents.coder import CodingAgent
+from agentic_coder.agents.planner import PlanResult
+from agentic_coder.retrieval.service import RetrievalDocument
+
+
+class _FakeModel:
+    async def chat(self, messages) -> str:  # noqa: ANN001
+        _ = messages
+        return (
+            '{"summary":"Update cache logic","target_files":["src/cache.py"],'
+            '"file_changes":[{"path":"src/cache.py","content":"def cache():\\n    return 42\\n"}]}'
+        )
+
+
+def test_coding_agent_parses_file_changes_from_model_response() -> None:
+    agent = CodingAgent(model=_FakeModel())
+    proposal = agent.propose(
+        PlanResult(objective="Update cache", steps=["edit file"]),
+        [
+            RetrievalDocument(
+                doc_id="src/cache.py",
+                text="def cache():\n    return 1\n",
+                metadata={"path": "src/cache.py"},
+            )
+        ],
+        repository="acme/widgets",
+    )
+
+    assert proposal.summary == "Update cache logic"
+    assert proposal.target_files == ["src/cache.py"]
+    assert len(proposal.file_changes) == 1
+    assert proposal.file_changes[0].path == "src/cache.py"
+    assert "return 42" in proposal.file_changes[0].content

--- a/tests/test_pull_requests.py
+++ b/tests/test_pull_requests.py
@@ -1,0 +1,28 @@
+from agentic_coder.pull_requests import extract_proposed_file_changes, is_safe_repo_relative_path
+
+
+def test_is_safe_repo_relative_path_rejects_unsafe_values() -> None:
+    assert is_safe_repo_relative_path("src/app.py") is True
+    assert is_safe_repo_relative_path("../etc/passwd") is False
+    assert is_safe_repo_relative_path("/tmp/file.py") is False
+    assert is_safe_repo_relative_path(".agentic/runs/run-1.md") is False
+
+
+def test_extract_proposed_file_changes_filters_invalid_paths() -> None:
+    changes = extract_proposed_file_changes(
+        [
+            {
+                "event_type": "proposal_generated",
+                "payload": {
+                    "target_files": ["src/app.py"],
+                    "file_changes": [
+                        {"path": "src/app.py", "content": "print('ok')\n"},
+                        {"path": "../evil.py", "content": "print('nope')\n"},
+                        {"path": "tests/test_app.py", "content": "print('extra')\n"},
+                    ],
+                },
+            }
+        ]
+    )
+
+    assert [change.path for change in changes] == ["src/app.py"]


### PR DESCRIPTION
## Summary
- teach the coding proposal to optionally carry concrete file contents for safe repo-relative target files
- apply those proposed file changes during worker-driven and manual PR creation, while still writing the run artifact for traceability
- document the new PR behavior and add regression coverage for proposal parsing, path filtering, and manual PR creation

## Validation
- ruff check --no-cache src tests --select I,F,E
- PYTEST_ADDOPTS='-p no:cacheprovider' pytest tests -q
- python scripts/smoke_test.py --base-url http://localhost:8080 --target-repository predictiv --wait-seconds 180

## Notes
- PR branches still include 
- if no concrete  are present, the branch remains artifact-only