### PR TITLE
Fix chat admin token prompt behavior

### DIFF
--- a/src/agentic_coder/api/chat.html
+++ b/src/agentic_coder/api/chat.html
@@ -286,6 +286,8 @@
   </div>
 
   <script>
+    window.AGENTIC_CHAT_CONFIG = __AGENTIC_CHAT_CONFIG__;
+
     const state = {
       sessions: [],
       activeSessionId: null,
@@ -306,6 +308,9 @@
       if (stored) {
         state.token = stored;
         return stored;
+      }
+      if (!window.AGENTIC_CHAT_CONFIG?.adminTokenRequired) {
+        return null;
       }
       const entered = window.prompt("Enter API admin token (X-Admin-Token):", "");
       if (entered) {

--- a/src/agentic_coder/api/main.py
+++ b/src/agentic_coder/api/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import re
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -633,7 +634,11 @@ def dashboard_page() -> str:
 @app.get("/chat", response_class=HTMLResponse)
 def chat_page(_admin: None = Depends(require_admin_token)) -> str:
     template_path = Path(__file__).with_name("chat.html")
-    return template_path.read_text(encoding="utf-8")
+    settings = get_settings()
+    return template_path.read_text(encoding="utf-8").replace(
+        "__AGENTIC_CHAT_CONFIG__",
+        json.dumps({"adminTokenRequired": bool(settings.api_admin_token)}),
+    )
 
 
 @app.post("/chat/sessions")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -430,6 +430,21 @@ def test_dashboard_data_endpoint(monkeypatch) -> None:
     assert task["pull_request"]["number"] == 7
 
 
+def test_chat_page_embeds_admin_token_requirement_flag(monkeypatch) -> None:
+    from agentic_coder.api import main
+
+    monkeypatch.setattr(
+        main,
+        "get_settings",
+        lambda: type("_Settings", (), {"api_admin_token": ""})(),
+    )
+
+    response = client.get("/chat")
+
+    assert response.status_code == 200
+    assert '"adminTokenRequired": false' in response.text
+
+
 class _ChatPolicy:
     class system:  # noqa: N801
         control_repository = "acme/control"


### PR DESCRIPTION
## Summary
- only prompt for X-Admin-Token in the chat UI when the backend actually requires API_ADMIN_TOKEN
- inject the backend auth requirement into the chat page config
- add regression coverage for the rendered chat page flag

## Validation
- ruff check --no-cache src tests scripts
- PYTEST_ADDOPTS='-p no:cacheprovider' pytest tests -q
- curl -fsS http://localhost:8080/chat | rg 'adminTokenRequired|Enter API admin token|AGENTIC_CHAT_CONFIG'
