### PR TITLE
Add chat model selector with cost tiers

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -302,6 +302,8 @@ The platform now includes a first-class chat intake UI at `GET /chat` for remote
 - Each session is bound to an allowed target repository
 - Operator identity is carried on each write via `X-Operator`
 - The page prompts for `X-Admin-Token` when `API_ADMIN_TOKEN` is configured
+- The page includes a runtime-backed model selector so operators can choose the execution model per session/run
+- GitHub-hosted model options are labeled with Copilot cost tiers: `0x` and `1x`
 - Session execution enqueues a normal task into the same pipeline and queue
 - Session transcripts are converted into task payloads with full run traceability
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Remote approvals remain GitHub-native in `gated` mode:
 - Comment `/approve` or `/approve <task_id>` on the control-repo issue thread
 - Comment `/reject <task_id> reason` or `/reject reason`
 - Chat executions in `gated` mode require an approval issue number so the worker knows where to post approval and status comments
+- The chat UI exposes a model dropdown sourced from the backend runtime, with cost labels:
+  - `0x`: no premium Copilot token charge
+  - `1x`: premium Copilot token charge
+  - `local`: local Ollama runtime
 
 ### GitHub PR workflow
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,10 +53,16 @@ The app also supports remote intake from `http://localhost:8080/chat`.
 
 1. Open `/chat`.
 2. If `API_ADMIN_TOKEN` is configured, enter it when prompted by the UI.
-3. Create a session for an allowed target repository.
+3. Create a session for an allowed target repository and choose the execution model from the dropdown.
 4. Add one or more messages describing the work.
 5. In `gated` mode, set an approval issue number on the session or execution request.
 6. Execute the session to enqueue it as a normal task.
+
+The model dropdown is populated from the live backend runtime:
+
+- `0x` means no premium Copilot token charge
+- `1x` means premium Copilot token charge
+- `local` means the configured Ollama model
 
 Chat sessions are persisted in PostgreSQL and linked back to any tasks they create.
 

--- a/src/agentic_coder/api/chat.html
+++ b/src/agentic_coder/api/chat.html
@@ -240,6 +240,11 @@
         <input class="input mono" id="sessionApprovalIssue" placeholder="123" />
       </div>
       <div class="stack">
+        <label class="sub" for="sessionModel">Execution Model</label>
+        <select class="select" id="sessionModel"></select>
+        <div class="sub" id="modelLegend">Select the model and cost tier for this chat run.</div>
+      </div>
+      <div class="stack">
         <label class="sub" for="operatorId">Operator Identity</label>
         <input class="input mono" id="operatorId" placeholder="alex.ops" />
       </div>
@@ -341,6 +346,66 @@
       return state.operator;
     }
 
+    function providerLabel(provider) {
+      if (provider === "github") return "GitHub Models";
+      if (provider === "ollama") return "Ollama";
+      return provider || "unknown";
+    }
+
+    function modelOptionLabel(option) {
+      const label = `${providerLabel(option.provider)} - ${option.displayName} (${option.costTier})`;
+      return option.recommended ? `${label} - recommended` : label;
+    }
+
+    function findModelOption(selectionKey) {
+      const options = window.AGENTIC_CHAT_CONFIG?.availableModels || [];
+      return options.find((option) => option.selectionKey === selectionKey) || null;
+    }
+
+    function selectedModelOption() {
+      const select = document.getElementById("sessionModel");
+      return findModelOption(select.value);
+    }
+
+    function syncModelSelector(preferredSelectionKey = null) {
+      const select = document.getElementById("sessionModel");
+      const options = window.AGENTIC_CHAT_CONFIG?.availableModels || [];
+      const defaultKey =
+        preferredSelectionKey ||
+        window.AGENTIC_CHAT_CONFIG?.defaultModelSelection?.selectionKey ||
+        options[0]?.selectionKey ||
+        "";
+      select.innerHTML = options.length
+        ? options
+            .map((option) => `
+              <option value="${escapeHtml(option.selectionKey)}">
+                ${escapeHtml(modelOptionLabel(option))}
+              </option>
+            `)
+            .join("")
+        : '<option value="">No configured models</option>';
+      select.disabled = !options.length;
+      if (defaultKey) {
+        select.value = defaultKey;
+      }
+      if (!select.value && options.length) {
+        select.value = options[0].selectionKey;
+      }
+      updateModelLegend();
+    }
+
+    function updateModelLegend() {
+      const selected = selectedModelOption();
+      const legend = document.getElementById("modelLegend");
+      if (!selected) {
+        legend.textContent = "No configured models are currently available.";
+        return;
+      }
+      const costMeaning =
+        window.AGENTIC_CHAT_CONFIG?.costLegend?.[selected.costTier] || "Configured model tier";
+      legend.textContent = `${providerLabel(selected.provider)} / ${selected.displayName} - ${selected.costTier}: ${costMeaning}`;
+    }
+
     async function api(path, options = {}) {
       const token = ensureToken();
       const operator = ensureOperator();
@@ -387,6 +452,7 @@
               <div><strong>${escapeHtml(session.title)}</strong></div>
               <div class="mono sub">${escapeHtml(session.target_repository)}</div>
               <div class="sub">approval issue: ${escapeHtml(session.approval_issue_number || "none")}</div>
+              <div class="sub">model: ${escapeHtml(session.selected_model?.displayName || "default")} (${escapeHtml(session.selected_model?.costTier || "-")})</div>
               <div class="sub">updated ${new Date(session.updated_at).toLocaleString()}</div>
             </button>
           `;
@@ -414,7 +480,10 @@
       const approval = session.approval_issue_number
         ? ` • approval issue: #${session.approval_issue_number}`
         : "";
-      metaEl.textContent = `session: ${session.session_id} • repo: ${session.target_repository}${approval}`;
+      const model = session.selected_model
+        ? ` • model: ${session.selected_model.displayName} (${session.selected_model.costTier})`
+        : "";
+      metaEl.textContent = `session: ${session.session_id} • repo: ${session.target_repository}${approval}${model}`;
     }
 
     function renderMessages(messages) {
@@ -452,6 +521,7 @@
               <div class="mono">task ${escapeHtml(task.task_id)}</div>
               <div class="state-${escapeHtml(task.state)}">state: ${escapeHtml(task.state)}</div>
               <div>run: ${escapeHtml(task.run?.run_id || "n/a")} (${escapeHtml(task.run?.status || "n/a")})</div>
+              <div>model: ${escapeHtml(task.run?.model_used || "n/a")}</div>
               <div>pr: ${prLink}</div>
             </div>
           `;
@@ -481,6 +551,8 @@
       const session = activeSession();
       renderActiveHeader();
       if (!session) return;
+      document.getElementById("sessionApprovalIssue").value = session.approval_issue_number || "";
+      syncModelSelector(session.selected_model?.selectionKey || null);
       setStatus("loading active");
       const [messagesData, runsData] = await Promise.all([
         api(`/chat/sessions/${session.session_id}/messages?limit=500`),
@@ -504,6 +576,7 @@
         window.alert("Approval issue must be a positive integer.");
         return;
       }
+      const selectedModel = selectedModelOption();
       setStatus("creating session");
       await api("/chat/sessions", {
         method: "POST",
@@ -511,6 +584,8 @@
           title,
           target_repository: targetRepository,
           approval_issue_number: approvalIssue,
+          model_provider: selectedModel?.provider || null,
+          model_name: selectedModel?.model || null,
         }),
       });
       document.getElementById("sessionTitle").value = "";
@@ -553,10 +628,15 @@
         window.alert("Approval issue must be a positive integer.");
         return;
       }
+      const selectedModel = selectedModelOption();
       setStatus("executing");
       const result = await api(`/chat/sessions/${session.session_id}/execute`, {
         method: "POST",
-        body: JSON.stringify({ approval_issue_number: approvalIssue }),
+        body: JSON.stringify({
+          approval_issue_number: approvalIssue,
+          model_provider: selectedModel?.provider || null,
+          model_name: selectedModel?.model || null,
+        }),
       });
       setStatus(result.reused ? "reused active task" : "execution enqueued");
       await refreshSessions();
@@ -604,7 +684,12 @@
       ensureOperator();
     });
 
+    document.getElementById("sessionModel").addEventListener("change", () => {
+      updateModelLegend();
+    });
+
     ensureOperator();
+    syncModelSelector();
     refreshSessions()
       .then(refreshActiveSession)
       .catch((error) => {

--- a/src/agentic_coder/api/main.py
+++ b/src/agentic_coder/api/main.py
@@ -17,6 +17,11 @@ from agentic_coder.db.session import create_session_factory
 from agentic_coder.domain.tasks import TaskState
 from agentic_coder.github_app.service import GitHubAppService, WebhookVerifier
 from agentic_coder.logging import configure_logging
+from agentic_coder.models.catalog import (
+    available_chat_models,
+    default_chat_model_selection,
+    find_chat_model_option,
+)
 from agentic_coder.policy.loader import PolicyLoader, resolve_policy_path
 from agentic_coder.pull_requests import apply_pull_request_changes, extract_proposed_file_changes
 from agentic_coder.queue.redis_queue import RedisTaskQueue
@@ -87,6 +92,8 @@ class CreateChatSessionRequest(BaseModel):
     title: str = Field(min_length=1, max_length=256)
     target_repository: str = Field(min_length=1, max_length=256)
     approval_issue_number: int | None = Field(default=None, ge=1)
+    model_provider: Literal["github", "ollama"] | None = None
+    model_name: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: dict[str, object] = Field(default_factory=dict)
 
 
@@ -102,6 +109,8 @@ class ExecuteChatSessionRequest(BaseModel):
     include_transcript_limit: int = Field(default=40, ge=1, le=200)
     force_new: bool = False
     approval_issue_number: int | None = Field(default=None, ge=1)
+    model_provider: Literal["github", "ollama"] | None = None
+    model_name: str | None = Field(default=None, min_length=1, max_length=256)
 
 
 class TaskDecisionRequest(BaseModel):
@@ -155,6 +164,91 @@ def parse_positive_int(value: object) -> int | None:
     if parsed <= 0:
         return None
     return parsed
+
+
+def parse_chat_model_selection(metadata: dict[str, object] | None) -> dict[str, str] | None:
+    raw = (metadata or {}).get("model_selection")
+    if not isinstance(raw, dict):
+        return None
+
+    provider = str(raw.get("provider") or "").strip()
+    model = str(raw.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    return {
+        "provider": provider,
+        "model": model,
+    }
+
+
+def validate_chat_model_selection(
+    *,
+    settings: object,
+    provider: str | None,
+    model: str | None,
+) -> dict[str, object] | None:
+    normalized_provider = str(provider or "").strip()
+    normalized_model = str(model or "").strip()
+    if not normalized_provider and not normalized_model:
+        return None
+    if not normalized_provider or not normalized_model:
+        raise HTTPException(
+            status_code=400,
+            detail="Both model_provider and model_name are required when selecting a model",
+        )
+
+    selected = find_chat_model_option(
+        settings,
+        provider=normalized_provider,
+        model=normalized_model,
+    )
+    if selected is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported chat model selection: {normalized_provider}:{normalized_model}",
+        )
+    return selected
+
+
+def serialize_chat_model_selection(
+    *,
+    settings: object,
+    metadata: dict[str, object] | None,
+    policy: object | None = None,
+) -> dict[str, object] | None:
+    selection = parse_chat_model_selection(metadata)
+    if selection is not None:
+        selected = find_chat_model_option(
+            settings,
+            provider=selection["provider"],
+            model=selection["model"],
+        )
+        if selected is not None:
+            return selected
+
+    if policy is None:
+        return None
+    return default_chat_model_selection(policy, settings)
+
+
+def serialize_chat_session_response(
+    chat_session: dict[str, object],
+    *,
+    settings: object,
+    policy: object,
+) -> dict[str, object]:
+    metadata = dict(chat_session.get("metadata") or {})
+    return {
+        **chat_session,
+        "approval_issue_number": parse_positive_int(metadata.get("approval_issue_number")),
+        "selected_model": serialize_chat_model_selection(
+            settings=settings,
+            metadata=metadata,
+            policy=policy,
+        ),
+        "created_at": chat_session["created_at"].isoformat(),
+        "updated_at": chat_session["updated_at"].isoformat(),
+    }
 
 
 def build_chat_transcript(
@@ -635,9 +729,25 @@ def dashboard_page() -> str:
 def chat_page(_admin: None = Depends(require_admin_token)) -> str:
     template_path = Path(__file__).with_name("chat.html")
     settings = get_settings()
+    _, policy = load_policy()
+    chat_config = {
+        "adminTokenRequired": bool(settings.api_admin_token),
+        "availableModels": available_chat_models(settings),
+        "defaultModelSelection": serialize_chat_model_selection(
+            settings=settings,
+            metadata=None,
+            policy=policy,
+        ),
+        "costLegend": {
+            "0x": "No premium Copilot token charge",
+            "1x": "Premium Copilot token charge",
+            "local": "Local runtime",
+            "custom": "Configured model not in the curated catalog",
+        },
+    }
     return template_path.read_text(encoding="utf-8").replace(
         "__AGENTIC_CHAT_CONFIG__",
-        json.dumps({"adminTokenRequired": bool(settings.api_admin_token)}),
+        json.dumps(chat_config),
     )
 
 
@@ -647,6 +757,7 @@ def create_chat_session(
     _admin: None = Depends(require_admin_token),
     x_operator: str | None = Header(default=None),
 ) -> dict[str, object]:
+    settings = get_settings()
     _, policy = load_policy()
     resolved_repository = expand_target_repository(policy, request_body.target_repository)
     if not is_target_repository_allowed(policy, resolved_repository):
@@ -659,6 +770,16 @@ def create_chat_session(
     metadata = dict(request_body.metadata)
     if request_body.approval_issue_number is not None:
         metadata["approval_issue_number"] = request_body.approval_issue_number
+    selected_model = validate_chat_model_selection(
+        settings=settings,
+        provider=request_body.model_provider,
+        model=request_body.model_name,
+    ) or default_chat_model_selection(policy, settings)
+    if selected_model is not None:
+        metadata["model_selection"] = {
+            "provider": selected_model["provider"],
+            "model": selected_model["model"],
+        }
 
     session_factory = create_session_factory()
     with session_factory() as session:
@@ -670,16 +791,12 @@ def create_chat_session(
             metadata=metadata,
         )
 
-    approval_issue_number = parse_positive_int(
-        (created.get("metadata") or {}).get("approval_issue_number")
-    )
     return {
-        "session": {
-            **created,
-            "approval_issue_number": approval_issue_number,
-            "created_at": created["created_at"].isoformat(),
-            "updated_at": created["updated_at"].isoformat(),
-        }
+        "session": serialize_chat_session_response(
+            created,
+            settings=settings,
+            policy=policy,
+        )
     }
 
 
@@ -688,20 +805,19 @@ def list_chat_sessions(
     limit: int = Query(default=50, ge=1, le=200),
     _admin: None = Depends(require_admin_token),
 ) -> dict[str, list[dict[str, object]]]:
+    settings = get_settings()
+    _, policy = load_policy()
     session_factory = create_session_factory()
     with session_factory() as session:
         repo = TaskRepository(session)
         sessions = repo.list_chat_sessions(limit=limit)
     return {
         "sessions": [
-            {
-                **item,
-                "approval_issue_number": parse_positive_int(
-                    (item.get("metadata") or {}).get("approval_issue_number")
-                ),
-                "created_at": item["created_at"].isoformat(),
-                "updated_at": item["updated_at"].isoformat(),
-            }
+            serialize_chat_session_response(
+                item,
+                settings=settings,
+                policy=policy,
+            )
             for item in sessions
         ]
     }
@@ -712,6 +828,8 @@ def get_chat_session(
     session_id: str,
     _admin: None = Depends(require_admin_token),
 ) -> dict[str, object]:
+    settings = get_settings()
+    _, policy = load_policy()
     session_factory = create_session_factory()
     with session_factory() as session:
         repo = TaskRepository(session)
@@ -719,14 +837,11 @@ def get_chat_session(
         if chat_session is None:
             raise HTTPException(status_code=404, detail="Chat session not found")
     return {
-        "session": {
-            **chat_session,
-            "approval_issue_number": parse_positive_int(
-                (chat_session.get("metadata") or {}).get("approval_issue_number")
-            ),
-            "created_at": chat_session["created_at"].isoformat(),
-            "updated_at": chat_session["updated_at"].isoformat(),
-        }
+        "session": serialize_chat_session_response(
+            chat_session,
+            settings=settings,
+            policy=policy,
+        )
     }
 
 
@@ -811,6 +926,7 @@ async def execute_chat_session(
     _admin: None = Depends(require_admin_token),
     x_operator: str | None = Header(default=None),
 ) -> dict[str, object]:
+    settings = get_settings()
     _, policy = load_policy()
     session_factory = create_session_factory()
 
@@ -853,6 +969,24 @@ async def execute_chat_session(
             raise HTTPException(status_code=400, detail="Chat session has no messages")
 
     metadata = dict(chat_session.get("metadata") or {})
+    explicit_selected_model = validate_chat_model_selection(
+        settings=settings,
+        provider=request_body.model_provider,
+        model=request_body.model_name,
+    )
+    selected_model = (
+        explicit_selected_model
+        or serialize_chat_model_selection(
+            settings=settings,
+            metadata=metadata,
+            policy=policy,
+        )
+    )
+    if selected_model is not None:
+        metadata["model_selection"] = {
+            "provider": selected_model["provider"],
+            "model": selected_model["model"],
+        }
     approval_issue_number = (
         request_body.approval_issue_number
         if request_body.approval_issue_number is not None
@@ -891,6 +1025,8 @@ async def execute_chat_session(
     session_factory = create_session_factory()
     with session_factory() as session:
         repo = TaskRepository(session)
+        if selected_model is not None:
+            repo.update_chat_session_metadata(session_id=session_id, metadata=metadata)
         task = repo.create(
             title=task_title,
             payload={
@@ -908,6 +1044,9 @@ async def execute_chat_session(
                 "requested_at": datetime.now(UTC).isoformat(),
                 "issue_number": approval_issue_number,
                 "approval_mode": "github_issue" if approval_issue_number else "none",
+                "model_provider": (selected_model or {}).get("provider"),
+                "model_name": (selected_model or {}).get("model"),
+                "model_cost_tier": (selected_model or {}).get("costTier"),
             },
         )
         repo.append_chat_message(
@@ -926,6 +1065,7 @@ async def execute_chat_session(
                 "target_repository": target_repository,
                 "force_new": request_body.force_new,
                 "approval_issue_number": approval_issue_number,
+                "selected_model": selected_model,
             },
         )
 
@@ -948,6 +1088,7 @@ async def execute_chat_session(
         "target_installation_id": target_installation_id,
         "source_installation_id": source_installation_id,
         "approval_issue_number": approval_issue_number,
+        "selected_model": selected_model,
     }
 
 

--- a/src/agentic_coder/db/repositories.py
+++ b/src/agentic_coder/db/repositories.py
@@ -313,6 +313,23 @@ class TaskRepository:
         sessions = self.session.scalars(stmt).all()
         return [self._chat_session_dict(item) for item in sessions]
 
+    def update_chat_session_metadata(
+        self,
+        *,
+        session_id: str,
+        metadata: dict[str, object],
+    ) -> dict[str, object] | None:
+        stmt = select(ChatSessionORM).where(ChatSessionORM.session_id == session_id)
+        session = self.session.scalar(stmt)
+        if session is None:
+            return None
+        session.metadata_json = metadata
+        session.updated_at = datetime.now(UTC)
+        self.session.add(session)
+        self.session.commit()
+        self.session.refresh(session)
+        return self._chat_session_dict(session)
+
     def append_chat_message(
         self,
         *,

--- a/src/agentic_coder/models/catalog.py
+++ b/src/agentic_coder/models/catalog.py
@@ -1,0 +1,139 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ChatModelOption:
+    provider: str
+    model: str
+    display_name: str
+    cost_tier: str
+    recommended: bool = False
+
+    @property
+    def selection_key(self) -> str:
+        return f"{self.provider}::{self.model}"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "displayName": self.display_name,
+            "costTier": self.cost_tier,
+            "recommended": self.recommended,
+            "selectionKey": self.selection_key,
+        }
+
+
+_GITHUB_CHAT_MODELS: tuple[ChatModelOption, ...] = (
+    ChatModelOption("github", "Phi-4", "Phi-4", "0x", recommended=True),
+    ChatModelOption("github", "Phi-4-mini", "Phi-4 mini", "0x"),
+    ChatModelOption("github", "gpt-4.1-mini", "GPT-4.1 mini", "0x"),
+    ChatModelOption("github", "gpt-4o-mini", "GPT-4o mini", "0x"),
+    ChatModelOption(
+        "github",
+        "Meta-Llama-3.3-70B-Instruct",
+        "Meta Llama 3.3 70B",
+        "0x",
+    ),
+    ChatModelOption("github", "gpt-4.1", "GPT-4.1", "1x"),
+    ChatModelOption("github", "claude-3-7-sonnet", "Claude 3.7 Sonnet", "1x"),
+)
+
+
+def available_chat_models(settings: object) -> list[dict[str, object]]:
+    options: list[ChatModelOption] = []
+
+    if getattr(settings, "github_models_api_key", ""):
+        options.extend(_GITHUB_CHAT_MODELS)
+        configured_model = str(getattr(settings, "github_models_chat_model", "") or "").strip()
+        if configured_model and configured_model not in {option.model for option in options}:
+            options.insert(
+                0,
+                ChatModelOption(
+                    "github",
+                    configured_model,
+                    configured_model,
+                    "custom",
+                ),
+            )
+
+    ollama_model = str(getattr(settings, "ollama_chat_model", "") or "").strip()
+    if ollama_model:
+        options.append(
+            ChatModelOption(
+                "ollama",
+                ollama_model,
+                ollama_model,
+                "local",
+            )
+        )
+
+    return [option.to_dict() for option in options]
+
+
+def find_chat_model_option(
+    settings: object,
+    *,
+    provider: str | None,
+    model: str | None,
+) -> dict[str, object] | None:
+    normalized_provider = str(provider or "").strip()
+    normalized_model = str(model or "").strip()
+    if not normalized_provider or not normalized_model:
+        return None
+
+    for option in available_chat_models(settings):
+        if (
+            option["provider"] == normalized_provider
+            and option["model"] == normalized_model
+        ):
+            return option
+    return None
+
+
+def default_chat_model_selection(policy: object, settings: object) -> dict[str, object] | None:
+    primary = str(getattr(policy.models, "primary_provider", "") or "").strip()
+    fallback = str(getattr(policy.models, "fallback_provider", "") or "").strip()
+
+    if primary == "auto":
+        if getattr(settings, "github_models_api_key", ""):
+            return find_chat_model_option(
+                settings,
+                provider="github",
+                model=getattr(settings, "github_models_chat_model", ""),
+            )
+        return find_chat_model_option(
+            settings,
+            provider="ollama",
+            model=getattr(settings, "ollama_chat_model", ""),
+        )
+
+    if primary == "github" and getattr(settings, "github_models_api_key", ""):
+        return find_chat_model_option(
+            settings,
+            provider="github",
+            model=getattr(settings, "github_models_chat_model", ""),
+        )
+
+    if primary == "ollama":
+        return find_chat_model_option(
+            settings,
+            provider="ollama",
+            model=getattr(settings, "ollama_chat_model", ""),
+        )
+
+    if fallback == "github" and getattr(settings, "github_models_api_key", ""):
+        return find_chat_model_option(
+            settings,
+            provider="github",
+            model=getattr(settings, "github_models_chat_model", ""),
+        )
+
+    if fallback == "ollama":
+        return find_chat_model_option(
+            settings,
+            provider="ollama",
+            model=getattr(settings, "ollama_chat_model", ""),
+        )
+
+    return None

--- a/src/agentic_coder/orchestration/pipeline.py
+++ b/src/agentic_coder/orchestration/pipeline.py
@@ -35,13 +35,21 @@ class PipelineResult:
 
 
 class TaskPipeline:
-    def __init__(self, workspace_root: Path) -> None:
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        model_provider_override: str | None = None,
+        model_name_override: str | None = None,
+    ) -> None:
         self.workspace_root = workspace_root
         self.retriever = InMemoryRetriever()
         self.context_agent = ContextRetrievalAgent(self.retriever)
         self.graph_builder = KnowledgeGraphBuilder()
         self.settings = get_settings()
         self.policy = PolicyLoader(path=Path("agentic.yaml")).load()
+        self.model_provider_override = str(model_provider_override or "").strip() or None
+        self.model_name_override = str(model_name_override or "").strip() or None
         self.router = self._build_model_router()
         provider_name, model_name = self._select_provider()
         self._model_used: str | None = f"{provider_name}:{model_name}" if provider_name else None
@@ -55,21 +63,38 @@ class TaskPipeline:
 
     def _build_model_router(self) -> ModelRouter:
         providers: dict[str, ModelProvider] = {}
+        github_model = (
+            self.model_name_override
+            if self.model_provider_override == "github" and self.model_name_override
+            else self.settings.github_models_chat_model
+        )
+        ollama_model = (
+            self.model_name_override
+            if self.model_provider_override == "ollama" and self.model_name_override
+            else self.settings.ollama_chat_model
+        )
         if self.settings.github_models_api_key:
             providers["github"] = GitHubHostedProvider(
                 api_key=self.settings.github_models_api_key,
-                model=self.settings.github_models_chat_model,
+                model=github_model,
                 base_url=self.settings.github_models_base_url,
                 timeout_seconds=self.settings.model_request_timeout_seconds,
             )
         providers["ollama"] = OllamaProvider(
-            model=self.settings.ollama_chat_model,
+            model=ollama_model,
             base_url=self.settings.ollama_base_url,
             timeout_seconds=self.settings.model_request_timeout_seconds,
         )
         return ModelRouter(providers=providers)
 
     def _select_provider(self) -> tuple[str | None, str | None]:
+        if (
+            self.model_provider_override
+            and self.model_name_override
+            and self.router.has(self.model_provider_override)
+        ):
+            return self.model_provider_override, self.model_name_override
+
         primary = self.policy.models.primary_provider
         fallback = self.policy.models.fallback_provider
 

--- a/src/agentic_coder/worker.py
+++ b/src/agentic_coder/worker.py
@@ -64,7 +64,6 @@ def process_task(
     autonomy_mode: str,
     workspace_root: Path,
 ) -> str:
-    pipeline = TaskPipeline(workspace_root=workspace_root)
     run_id = repo.create_run(task_id, worker_name="worker")
     try:
         repo.append_run_event(
@@ -101,6 +100,12 @@ def process_task(
         current_task = repo.get_by_id(task_id)
         if current_task is None:
             raise ValueError(f"Task not found during processing: {task_id}")
+        pipeline = TaskPipeline(
+            workspace_root=workspace_root,
+            model_provider_override=str(current_task.payload.get("model_provider") or "").strip()
+            or None,
+            model_name_override=str(current_task.payload.get("model_name") or "").strip() or None,
+        )
         result = pipeline.run(current_task)
 
         source_repo_name = str(current_task.payload.get("source_repository") or "").split(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -436,13 +436,27 @@ def test_chat_page_embeds_admin_token_requirement_flag(monkeypatch) -> None:
     monkeypatch.setattr(
         main,
         "get_settings",
-        lambda: type("_Settings", (), {"api_admin_token": ""})(),
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "api_admin_token": "",
+                "github_models_api_key": "ghp-test",
+                "github_models_chat_model": "Phi-4",
+                "ollama_chat_model": "llama3.1:8b",
+            },
+        )(),
     )
+    monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
 
     response = client.get("/chat")
 
     assert response.status_code == 200
     assert '"adminTokenRequired": false' in response.text
+    assert '"selectionKey": "github::Phi-4"' in response.text
+    assert '"costTier": "0x"' in response.text
+    assert '"selectionKey": "github::gpt-4.1"' in response.text
+    assert '"costTier": "1x"' in response.text
 
 
 class _ChatPolicy:
@@ -471,6 +485,7 @@ class _ChatExecutionRepo:
     created_payload: dict[str, object] | None = None
     appended_messages: list[dict[str, object]] = []
     session_metadata: dict[str, object] = {}
+    updated_metadata: dict[str, object] | None = None
 
     def __init__(self, session) -> None:  # noqa: ANN001
         self.session = session
@@ -541,6 +556,26 @@ class _ChatExecutionRepo:
         self.__class__.appended_messages.append(message)
         return message
 
+    def update_chat_session_metadata(
+        self,
+        *,
+        session_id: str,
+        metadata: dict[str, object],
+    ) -> dict[str, object] | None:
+        if session_id != "chat-1":
+            return None
+        self.__class__.updated_metadata = dict(metadata)
+        now = datetime.now(UTC)
+        return {
+            "session_id": "chat-1",
+            "title": "Enterprise request",
+            "target_repository": "acme/predictiv",
+            "created_by": "alex.ops",
+            "metadata": dict(metadata),
+            "created_at": now,
+            "updated_at": now,
+        }
+
 
 def test_execute_chat_session_requires_issue_number_when_gated(monkeypatch) -> None:
     from agentic_coder.api import main
@@ -548,9 +583,24 @@ def test_execute_chat_session_requires_issue_number_when_gated(monkeypatch) -> N
     _ChatExecutionRepo.created_payload = None
     _ChatExecutionRepo.appended_messages = []
     _ChatExecutionRepo.session_metadata = {}
+    _ChatExecutionRepo.updated_metadata = None
     monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
     monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
     monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
+    monkeypatch.setattr(
+        main,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "api_admin_token": "",
+                "github_models_api_key": "ghp-test",
+                "github_models_chat_model": "Phi-4",
+                "ollama_chat_model": "llama3.1:8b",
+            },
+        )(),
+    )
 
     response = client.post("/chat/sessions/chat-1/execute", json={})
 
@@ -565,10 +615,25 @@ def test_execute_chat_session_routes_source_and_target_installations(monkeypatch
     _ChatExecutionRepo.created_payload = None
     _ChatExecutionRepo.appended_messages = []
     _ChatExecutionRepo.session_metadata = {"approval_issue_number": 77}
+    _ChatExecutionRepo.updated_metadata = None
 
     monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
     monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
     monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
+    monkeypatch.setattr(
+        main,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "api_admin_token": "",
+                "github_models_api_key": "ghp-test",
+                "github_models_chat_model": "Phi-4",
+                "ollama_chat_model": "llama3.1:8b",
+            },
+        )(),
+    )
 
     async def _fake_installation_lookup(repository: str) -> int:
         if repository == "acme/control":
@@ -581,7 +646,10 @@ def test_execute_chat_session_routes_source_and_target_installations(monkeypatch
     fake_queue = _FakeQueue()
     monkeypatch.setattr(main.RedisTaskQueue, "from_settings", lambda: fake_queue)
 
-    response = client.post("/chat/sessions/chat-1/execute", json={})
+    response = client.post(
+        "/chat/sessions/chat-1/execute",
+        json={"model_provider": "github", "model_name": "gpt-4.1"},
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -590,6 +658,9 @@ def test_execute_chat_session_routes_source_and_target_installations(monkeypatch
     assert data["approval_issue_number"] == 77
     assert data["source_installation_id"] == 111
     assert data["target_installation_id"] == 222
+    assert data["selected_model"]["provider"] == "github"
+    assert data["selected_model"]["model"] == "gpt-4.1"
+    assert data["selected_model"]["costTier"] == "1x"
     assert fake_queue.enqueued == ["chat-task-1"]
 
     assert _ChatExecutionRepo.created_payload is not None
@@ -599,3 +670,10 @@ def test_execute_chat_session_routes_source_and_target_installations(monkeypatch
     assert payload["target_installation_id"] == 222
     assert payload["installation_id"] == 222
     assert payload["issue_number"] == 77
+    assert payload["model_provider"] == "github"
+    assert payload["model_name"] == "gpt-4.1"
+    assert payload["model_cost_tier"] == "1x"
+    assert _ChatExecutionRepo.updated_metadata == {
+        "approval_issue_number": 77,
+        "model_selection": {"provider": "github", "model": "gpt-4.1"},
+    }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,27 @@
 from datetime import UTC, datetime
+from pathlib import Path
 
 from agentic_coder.domain.tasks import TaskRecord, TaskState
+from agentic_coder.orchestration import pipeline as pipeline_module
 from agentic_coder.orchestration.pipeline import TaskPipeline
 
 
-def test_pipeline_runs_and_generates_outputs(tmp_path) -> None:
+class _Policy:
+    class models:  # noqa: N801
+        primary_provider = "github"
+        fallback_provider = None
+
+
+class _Settings:
+    github_models_api_key = "ghp-test"
+    github_models_chat_model = "Phi-4"
+    github_models_base_url = "https://models.inference.ai.azure.com"
+    ollama_chat_model = "llama3.1:8b"
+    ollama_base_url = "http://ollama:11434"
+    model_request_timeout_seconds = 40.0
+
+
+def test_pipeline_runs_and_generates_outputs(tmp_path: Path) -> None:
     source = tmp_path / "sample.py"
     source.write_text("def hello():\n    return 'world'\n", encoding="utf-8")
 
@@ -30,3 +47,21 @@ def test_pipeline_runs_and_generates_outputs(tmp_path) -> None:
     assert result.graph_summary["nodes"] >= 2
     assert result.indexed_files >= 1
     assert result.pr_draft.title.startswith("[acme/widgets]")
+
+
+def test_pipeline_uses_model_override(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(pipeline_module, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(
+        pipeline_module.PolicyLoader,
+        "load",
+        lambda self: _Policy(),
+    )
+
+    pipeline = TaskPipeline(
+        workspace_root=tmp_path,
+        model_provider_override="github",
+        model_name_override="gpt-4.1",
+    )
+
+    assert pipeline._model_used == "github:gpt-4.1"
+    assert pipeline.router.get("github").model == "gpt-4.1"

--- a/tests/test_worker_process_task.py
+++ b/tests/test_worker_process_task.py
@@ -113,8 +113,14 @@ def test_resolve_workspace_root_by_repo_name() -> None:
 
 def test_process_task_fails_on_control_repo_path_leak(monkeypatch) -> None:
     class _LeakyPipeline:
-        def __init__(self, workspace_root: Path) -> None:
-            _ = workspace_root
+        def __init__(
+            self,
+            workspace_root: Path,
+            *,
+            model_provider_override: str | None = None,
+            model_name_override: str | None = None,
+        ) -> None:
+            _ = workspace_root, model_provider_override, model_name_override
 
         def run(self, task: TaskRecord) -> _PipelineResult:
             _ = task


### PR DESCRIPTION
## Summary
- add a chat UI model selector backed by the live runtime model catalog
- label GitHub-hosted models with 0x and 1x cost tiers and show the current selection in session views
- carry the selected provider/model through chat execution so the pipeline actually uses the requested model
- document the new operator workflow in README, USAGE, and PRODUCT docs

## Validation
- ruff check --no-cache src tests scripts
- PYTEST_ADDOPTS='-p no:cacheprovider' pytest tests -q
- make smoke
- curl -fsS http://localhost:8080/chat | rg 'availableModels|selectionKey|costTier|sessionModel|Execution Model|gpt-4.1|Phi-4'
