### PR TITLE
Pivot chat into GitHub-agent control plane

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,11 +2,34 @@
 
 ## Overview
 
-Agentic Coder is a local-first, GitHub-native autonomous AI development platform. It runs as a self-hosted service that monitors a dedicated **control repository** on GitHub, picks up natural-language engineering tasks posted as issue comments, and autonomously plans, retrieves context, reviews, and opens draft pull requests in one or more **target repositories** — all without requiring a public webhook endpoint.
+Agentic Coder is a self-hosted AI engineering control plane.
 
-The platform is designed around a human-in-the-loop approval model: in `gated` mode (default), every proposed change waits for explicit sign-off via a GitHub comment before a PR is opened. In `autonomous` mode, the agent acts end-to-end without pausing.
+Its primary job is no longer to act as a homegrown replacement for GitHub's coding worker. The stronger product shape is:
 
-Current implementation note: the PR branch always contains a run artifact (`.agentic/runs/<run_id>.md`). When the coding proposal includes concrete file contents, those files are also written into the target-repository branch before the PR opens. If no concrete file contents are available, the PR remains artifact-only.
+- `Agentic Coder` handles intake, clarification, policy, audit trail, model routing, and operator UX
+- `GitHub Copilot coding agent` handles most implementation work
+- the local worker pipeline remains available as a fallback backend
+
+This lets you run a private remote endpoint over your own network or Tailscale while still using GitHub's native issue, branch, PR, and review flows for the actual coding work.
+
+---
+
+## Product Positioning
+
+### What the product is
+
+- private AI engineering manager
+- remote chat intake surface
+- policy and governance layer
+- run/event/task audit system
+- dispatch layer into GitHub coding agent
+- optional local execution fallback
+
+### What the product is not
+
+- a full replacement for GitHub's coding agent
+- a local clone of GitHub's implementation engine
+- a substitute for GitHub's PR review and merge UX
 
 ---
 
@@ -16,55 +39,137 @@ Current implementation note: the PR branch always contains a run artifact (`.age
 
 | Service | Role |
 |---|---|
-| `api` | FastAPI control plane — webhooks, task management, dashboard |
-| `worker` | Polling loop and task pipeline executor |
-| `executor` | Sandbox execution for running tests and shell commands |
-| `postgres` | Durable state store (tasks, runs, events, transitions, poll cursors) |
-| `redis` | Task queue between API/webhook receiver and worker |
-| `ollama` *(optional)* | Local LLM fallback (disabled by default when GitHub Models key is set) |
+| `api` | FastAPI control plane — chat, dashboard, health, self-check, task APIs |
+| `worker` | Polling loop and local-pipeline executor |
+| `executor` | Sandbox execution for local shell/test operations |
+| `postgres` | Durable state store for tasks, runs, events, cursors, sessions, and messages |
+| `redis` | Queue for local worker execution |
+| `ollama` *(optional)* | Local LLM runtime for manager/planning or local execution fallback |
 
-### High-Level Flow
+### Primary Operating Modes
 
-```
-GitHub Issue Comment
+#### 1. Chat -> GitHub coding agent (default)
+
+```text
+Remote Operator
       │
       ▼
-Worker polling loop (every N seconds)
-      │  detects command syntax (@agent, repo=, /approve, /reject)
+/chat session
+      │  create session + add messages
       ▼
-Task normalisation → PostgreSQL + Redis queue
+ChatManagerAgent
+  ├── clarifies request
+  ├── decides ready vs needs-more-info
+  └── prepares GitHub issue payload
       │
       ▼
-Worker dequeues task
+GitHub issue creation + coding-agent assignment
       │
       ▼
-TaskPipeline
-  ├── PlannerAgent        (LLM: plan objective + steps)
-  ├── ContextRetrievalAgent (index workspace .py files, keyword retrieval)
-  ├── KnowledgeGraphBuilder (file/symbol graph)
-  ├── CodingAgent         (LLM: propose files and summary)
-  ├── ReviewerAgent       (LLM: approve/reject proposal)
-  ├── SecurityAgent       (LLM + static: scan for risks)
-  ├── TestAgent           (LLM: generate validation commands)
-  └── PullRequestGenerator (LLM: write PR title + body)
+Local audit trail
+  ├── task created
+  ├── run created
+  ├── events appended
+  └── state = delegated
       │
       ▼
-[gated mode] Post approval-request comment → wait for /approve
-[autonomous mode] Proceed immediately
+GitHub coding agent executes in GitHub environment
       │
       ▼
-Create branch → commit proposed file changes + artifact → open draft PR in target repo
-      │
-      ▼
-Post status update comment on source issue
+GitHub opens PR in target repository
 ```
 
-### Current Execution Semantics
+#### 2. Chat -> local pipeline (fallback)
 
-- The pipeline generates a `PatchProposal`, review result, security result, test plan, and PR draft
-- Approval and status comments are posted back to the control-repository issue when issue context is present
-- Target-repository PRs always contain a run artifact and may also contain model-proposed file changes
-- Direct patch application currently depends on the coding agent returning full file contents for files already present in retrieved context
+```text
+Remote Operator
+      │
+      ▼
+/chat session
+      │
+      ▼
+Task creation + Redis enqueue
+      │
+      ▼
+Local worker executes TaskPipeline
+      │
+      ▼
+Branch creation + file writes + draft PR
+```
+
+#### 3. GitHub comment -> local pipeline
+
+```text
+GitHub issue comment in control repository
+      │
+      ▼
+Worker polling loop
+      │ detects @agent / repo= / /repo / /approve / /reject
+      ▼
+Task normalization -> PostgreSQL + Redis
+      │
+      ▼
+Local worker executes TaskPipeline
+```
+
+---
+
+## Core Concepts
+
+### Chat Control Plane
+
+The `/chat` UI is the main operator surface.
+
+It supports:
+
+- persistent sessions
+- ordered message history
+- target repository selection
+- base branch override
+- custom agent name
+- manager-model selection
+- clarification before dispatch
+- run history per session
+
+### Manager Model
+
+The selected model in `/chat` is used by Agentic Coder for:
+
+- clarification
+- request shaping
+- dispatch planning
+- issue body generation
+
+Model cost labels shown in the UI:
+
+- `0x`: no premium Copilot token charge for the manager model
+- `1x`: premium Copilot token charge for the manager model
+- `local`: runs through Ollama locally
+
+These labels apply to the manager model only. GitHub coding-agent execution still carries GitHub-side cost for Actions minutes and Copilot premium requests.
+
+### Execution Backend
+
+Configured in `agentic.yaml`:
+
+```yaml
+chat:
+  execution_backend: github_coding_agent   # github_coding_agent | local_pipeline
+  auto_prepare: true
+```
+
+- `github_coding_agent` is the default and recommended mode
+- `local_pipeline` is the fallback self-hosted execution mode
+
+### Delegated State
+
+A delegated task is a task that Agentic Coder prepared and handed off to GitHub coding agent.
+
+`delegated` means:
+
+- a local audit record exists
+- the request was successfully dispatched
+- implementation is now happening outside the local worker
 
 ---
 
@@ -72,204 +177,97 @@ Post status update comment on source issue
 
 ### Task States
 
-```
-RECEIVED → NORMALIZED → INDEXED → PLANNED → AWAITING_APPROVAL → READY → RUNNING → SUCCEEDED
-                                          ↘ (autonomous mode) ↗               ↘ FAILED
-                                                                                ↘ CANCELLED
+```text
+RECEIVED -> NORMALIZED -> INDEXED -> PLANNED -> AWAITING_APPROVAL -> READY -> RUNNING -> SUCCEEDED
+                                          \ (autonomous mode)    /               \ FAILED
+
+Chat dispatch path:
+RECEIVED -> NORMALIZED -> PLANNED -> RUNNING -> DELEGATED
 ```
 
 | State | Meaning |
 |---|---|
-| `received` | Task created from webhook or poll |
+| `received` | Task created from webhook, poll, or chat dispatch audit |
 | `normalized` | Payload extracted and validated |
-| `indexed` | Workspace and context indexed |
-| `planned` | Pipeline has produced a plan |
-| `awaiting_approval` | Gated mode: waiting for human `/approve` |
-| `ready` | Approved or autonomous — ready to execute |
-| `running` | Pipeline actively running |
-| `succeeded` | PR created successfully |
-| `failed` | Pipeline or PR creation error |
+| `indexed` | Local pipeline context indexed |
+| `planned` | Local plan or dispatch plan prepared |
+| `awaiting_approval` | Local gated flow waiting for human `/approve` |
+| `ready` | Approved or autonomous local task |
+| `running` | Local worker or dispatch audit currently executing |
+| `delegated` | Handed off to GitHub coding agent |
+| `succeeded` | Local pipeline completed successfully |
+| `failed` | Local pipeline or dispatch failed |
 | `cancelled` | Rejected or manually cancelled |
 
 ### Database Tables
 
 | Table | Purpose |
 |---|---|
-| `tasks` | One row per task; holds payload JSONB and current state |
-| `runs` | One run per task execution; holds metadata and status |
-| `task_transitions` | Append-only log of every state change with reason and details |
-| `run_events` | Granular event timeline per run (plan_created, proposal_generated, pr_draft, etc.) |
-| `poll_cursors` | Durable per-repo polling position (last `updated_at` seen) |
-| `chat_sessions` | Persistent remote-operator chat sessions bound to target repositories |
-| `chat_messages` | Ordered transcript messages stored for each chat session |
+| `tasks` | One row per task with payload JSON and current state |
+| `runs` | One row per execution or dispatch audit |
+| `task_transitions` | Append-only state transition log |
+| `run_events` | Event timeline for planning, dispatch, PR creation, and approvals |
+| `poll_cursors` | Durable per-repo polling position |
+| `chat_sessions` | Persistent operator sessions |
+| `chat_messages` | Ordered transcript for each session |
 
 ---
 
-## Agent Pipeline
+## Local Pipeline
 
-All agents receive the same `ModelProvider` instance resolved at pipeline init. Each agent has a model-backed implementation and a stub fallback used when the model call fails or no provider is configured.
+The local pipeline still exists and remains useful for fallback or self-hosted-only scenarios.
 
-### PlannerAgent
-- **Input:** issue title + body
-- **Output:** `PlanResult` — objective string + ordered list of implementation steps
-- **Model prompt:** produces JSON `{objective, steps}`
+### Agents
 
-### ContextRetrievalAgent
-- **Input:** workspace root path
-- **Output:** list of `RetrievalDocument` (ranked by keyword overlap with query)
-- **No LLM** — indexes all `.py` files in workspace, keyword-scores against query terms
+- `PlannerAgent`
+- `ContextRetrievalAgent`
+- `KnowledgeGraphBuilder`
+- `CodingAgent`
+- `ReviewerAgent`
+- `SecurityAgent`
+- `TestAgent`
+- `PullRequestGenerator`
 
-### KnowledgeGraphBuilder
-- **Input:** workspace root
-- **Output:** `{nodes, edges}` summary counts
-- **No LLM** — walks directory tree, builds file/symbol graph nodes
+### Current semantics
 
-### CodingAgent
-- **Input:** `PlanResult` + context documents + repository name
-- **Output:** `PatchProposal` — summary of changes + list of target file paths + optional full-file updates
-- **Model prompt:** produces JSON `{summary, target_files, file_changes}` constrained to files present in context
-
-### ReviewerAgent
-- **Input:** `PatchProposal`
-- **Output:** `ReviewResult` — approved bool + feedback string
-- **Model prompt:** produces JSON `{approved, feedback}`
-
-### SecurityAgent
-- **Input:** issue/comment body text
-- **Output:** `SecurityResult` — passed bool + findings list
-- **Dual check:** static marker scan (rm -rf, drop table, disable auth) AND model scan; fails if either fails; findings are merged
-
-### TestAgent
-- **Input:** `PlanResult` + `PatchProposal`
-- **Output:** `ExecutionTestPlan` — ordered list of shell commands
-- **Model prompt:** produces JSON `{commands}` targeted to affected files
-
-### PullRequestGenerator
-- **Input:** repo name + `PlanResult` + `PatchProposal`
-- **Output:** `PullRequestDraft` — title + markdown body
-- **Model prompt:** produces JSON `{title, body}` with sections: Summary, Changes, Testing
+- the pipeline can produce proposed file changes when the proposal includes concrete full-file content
+- the local PR flow still writes `.agentic/runs/<run_id>.md`
+- local patch application is constrained by proposal quality and available retrieved context
 
 ---
 
-## Model Configuration
+## GitHub Dispatch Integration
 
-### Provider Abstraction
+### Required credentials
 
-All LLM calls go through `ModelProvider` → `ModelRouter`. Two providers are implemented:
+Two different GitHub credential paths are involved:
 
-| Provider | Class | Endpoint |
-|---|---|---|
-| GitHub Models (Copilot) | `GitHubHostedProvider` | `https://models.inference.ai.azure.com` |
-| Ollama (local) | `OllamaProvider` | `http://ollama:11434` |
+1. `GitHub App credentials`
+   - used for repo integration, polling, comments, branch work, and local PR operations
+2. `GITHUB_AGENT_USER_TOKEN`
+   - used for issue creation that assigns GitHub coding agent in the target repository
 
-Provider selection is controlled by `agentic.yaml`:
+### Dispatch behavior
 
-```yaml
-models:
-  primary_provider: github   # github | ollama | auto
-  fallback_provider: null    # null to disable fallback
-  embedding_provider: github
-```
+When the chat backend is `github_coding_agent` and the request is ready:
 
-`auto` prefers GitHub if `GITHUB_MODELS_API_KEY` is set, otherwise falls back to Ollama.
+1. Agentic Coder prepares the issue title, issue body, and custom instructions.
+2. It creates a GitHub issue in the target repository.
+3. It assigns `copilot-swe-agent[bot]`.
+4. It records local events such as:
+   - `dispatch_prepared`
+   - `github_agent_issue_created`
+   - `github_agent_dispatched`
+5. It marks the task `delegated`.
 
-### Current Model
+### Installation context separation
 
-| Setting | Value |
-|---|---|
-| Provider | GitHub Models (Copilot) |
-| Model | `Phi-4` |
-| Reason | Best free-tier model for software development tasks — optimised for code reasoning |
-| Auth | Classic PAT (`ghp_...`) with active Copilot subscription |
+Local tasks may carry both:
 
-### Changing the Model
+- `source_installation_id`
+- `target_installation_id`
 
-Set `GITHUB_MODELS_CHAT_MODEL` in `.env`:
-
-```
-GITHUB_MODELS_CHAT_MODEL=Phi-4
-```
-
-Free-tier (0x) models available:
-
-| Model | Name |
-|---|---|
-| Phi-4 *(current — recommended for code)* | `Phi-4` |
-| Phi-4 mini | `Phi-4-mini` |
-| GPT-4.1 mini | `gpt-4.1-mini` |
-| GPT-4o mini | `gpt-4o-mini` |
-| Meta Llama 3.3 70B | `Meta-Llama-3.3-70B-Instruct` |
-
-Premium models (consume Copilot quota):
-
-| Model | Name |
-|---|---|
-| GPT-4.1 | `gpt-4.1` |
-| Claude 3.7 Sonnet | `claude-3-7-sonnet` |
-
----
-
-## Policy Configuration (`agentic.yaml`)
-
-```yaml
-version: 1
-
-system:
-  name: agentic-coder
-  environment: development
-  control_repository: owner/agentic_coder      # repo the agent polls for commands
-  allow_any_target_repository: false           # must be false in production
-  allowed_target_repositories:
-    - myorg/myrepo                             # explicitly allowed targets
-  local_repository_paths:
-    myrepo: /repos/myrepo                      # workspace path inside container
-  default_target_base_branch: develop
-  target_base_branches:
-    myorg/myrepo: develop
-
-autonomy:
-  mode: gated                                  # gated (requires /approve) | autonomous
-  allowed_actions:
-    - plan
-    - retrieve_context
-    - build_knowledge_graph
-    - write_patch
-    - run_tests
-    - create_pr
-  approval_required_actions:
-    - execute_shell
-    - merge_pr
-    - enable_network
-
-sandbox:
-  profile: compose
-  network_enabled: false
-  network_allowlist: []
-  max_runtime_seconds: 900
-  max_cpu_cores: 2
-  max_memory_mb: 2048
-
-models:
-  primary_provider: github
-  fallback_provider: null
-  embedding_provider: github
-
-trigger:
-  mode: polling                                # polling | webhook | hybrid
-  poll_interval_seconds: 60
-  max_items_per_poll: 50
-
-knowledge_graph:
-  enabled: true
-  storage: postgres
-  node_types: [repo, commit, file, symbol, test, issue, pr, task, artifact, decision]
-  edge_types: [contains, imports, defines, references, calls, changes, mentions, derived_from, related_to]
-
-budgets:
-  max_prompt_tokens: 32000
-  max_completion_tokens: 8000
-  max_parallel_candidates: 1
-```
+This prevents cross-repo confusion when the control repository and target repository differ.
 
 ---
 
@@ -277,110 +275,56 @@ budgets:
 
 ### Polling (default)
 
-- Worker polls `system.control_repository` issue comments on a timer
-- No public webhook endpoint required — works behind NAT/firewall
-- Durable cursor stored in `poll_cursors` table — survives restarts
-- Bot comments automatically filtered out to prevent feedback loops
+- worker polls `system.control_repository`
+- no public webhook endpoint required
+- bot comments are filtered out
+- durable cursor stored in `poll_cursors`
 
 ### Webhook
 
-- API receives `POST /webhook` with GitHub `X-Hub-Signature-256` verification
-- HMAC-SHA256 validation using `GITHUB_WEBHOOK_SECRET`
-- Immediately enqueues task to Redis
+- API receives `POST /github/webhook`
+- validates `X-Hub-Signature-256`
+- immediately enqueues local tasks
 
 ### Hybrid
 
-- Both polling and webhook active simultaneously
-
----
-
-## Chat Control Plane (Enterprise Intake)
-
-The platform now includes a first-class chat intake UI at `GET /chat` for remote operation.
-
-- Persistent chat sessions are stored in PostgreSQL (`chat_sessions`, `chat_messages`)
-- Each session is bound to an allowed target repository
-- Operator identity is carried on each write via `X-Operator`
-- The page prompts for `X-Admin-Token` when `API_ADMIN_TOKEN` is configured
-- The page includes a runtime-backed model selector so operators can choose the execution model per session/run
-- GitHub-hosted model options are labeled with Copilot cost tiers: `0x` and `1x`
-- Session execution enqueues a normal task into the same pipeline and queue
-- Session transcripts are converted into task payloads with full run traceability
-
-### Gated Mode with Chat
-
-In `gated` autonomy mode, chat execution requires a GitHub approval issue number so approvals remain remote and GitHub-native:
-
-- Set `approval_issue_number` on session create, or pass it during execute
-- Worker posts approval-request/status comments to the control repository issue
-- `/approve` and `/reject` comments continue to drive transitions and PR creation
-- The resulting PR always contains a run artifact and may also contain model-proposed file updates when available
-
-### Installation Context Separation
-
-Task payloads carry both installation contexts:
-
-- `source_installation_id` for source/control repo issue comments + labels
-- `target_installation_id` for branch/commit/PR operations in target repo
-
-This prevents cross-repo token misuse when source and target repos are not under the same installation.
+- polling and webhook enabled together
 
 ---
 
 ## Command Syntax (GitHub Comments)
 
-### Triggering a Task
+### Triggering a local task
 
-```
+```text
 @agent repo=owner/reponame
 Description of the change to make
 ```
 
-```
+```text
 /repo owner/reponame
 Description of the change to make
 ```
 
-```
-@agent repo=reponame add a health check endpoint
-```
+### Approving a local gated task
 
-### Approving a Task (gated mode)
-
-```
+```text
 /approve
 ```
-Approves the latest `awaiting_approval` task on this issue.
 
-```
+```text
 /approve <task_id>
 /approve task=<task_id>
 ```
-Approves a specific task by ID.
 
-### Rejecting a Task
+### Rejecting a local gated task
 
-```
+```text
 /reject reason goes here
 /reject <task_id> reason goes here
 ```
 
----
-
-## GitHub App Requirements
-
-### Required Permissions
-
-| Permission | Level |
-|---|---|
-| Metadata | Read |
-| Contents | Read & Write |
-| Pull requests | Read & Write |
-| Issues | Read & Write |
-
-### Required Events (webhook mode)
-
-- `issue_comment`
+These approval commands apply to the local worker pipeline. They are not required for the default GitHub-agent chat dispatch flow.
 
 ---
 
@@ -389,27 +333,31 @@ Approves a specific task by ID.
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/healthz` | Liveness probe |
-| `GET` | `/readyz` | Readiness probe (DB + Redis) |
-| `GET` | `/self-check` | Full startup diagnostics |
-| `POST` | `/webhook` | GitHub App webhook receiver |
-| `POST` | `/tasks` | Create task manually |
+| `GET` | `/readyz` | Readiness probe |
+| `GET` | `/self-check` | Startup diagnostics alias |
+| `GET` | `/startup/self-check` | Current startup self-check result |
+| `POST` | `/startup/self-check/run` | Re-run GitHub self-check |
+| `GET` | `/polling/status` | Polling configuration and cursor state |
+| `POST` | `/github/webhook` | GitHub webhook receiver |
+| `POST` | `/tasks` | Create a task manually |
 | `GET` | `/tasks` | List recent tasks |
 | `GET` | `/tasks/{task_id}` | Task detail |
-| `POST` | `/tasks/{task_id}/approve` | Approve a gated task |
-| `POST` | `/tasks/{task_id}/reject` | Reject a task |
+| `POST` | `/tasks/{task_id}/approve` | Approve a local gated task |
+| `POST` | `/tasks/{task_id}/reject` | Reject a local gated task |
 | `GET` | `/runs/{run_id}` | Run detail |
 | `GET` | `/runs/{run_id}/events` | Run event timeline |
-| `POST` | `/runs/{run_id}/pull-request` | Manually trigger PR creation for a run |
+| `POST` | `/runs/{run_id}/pull-request` | Manually trigger local PR creation |
 | `GET` | `/dashboard` | HTML dashboard UI |
 | `GET` | `/dashboard/data` | Dashboard JSON data |
 | `GET` | `/chat` | Chat control-plane UI |
-| `POST` | `/chat/sessions` | Create chat session |
-| `GET` | `/chat/sessions` | List chat sessions |
-| `GET` | `/chat/sessions/{session_id}` | Chat session detail |
-| `GET` | `/chat/sessions/{session_id}/messages` | Chat transcript messages |
-| `POST` | `/chat/sessions/{session_id}/messages` | Append chat message |
-| `GET` | `/chat/sessions/{session_id}/runs` | Task/run history for session |
-| `POST` | `/chat/sessions/{session_id}/execute` | Enqueue chat session as pipeline task |
+| `POST` | `/chat/sessions` | Create a chat session |
+| `GET` | `/chat/sessions` | List sessions |
+| `GET` | `/chat/sessions/{session_id}` | Session detail |
+| `GET` | `/chat/sessions/{session_id}/messages` | Session transcript |
+| `POST` | `/chat/sessions/{session_id}/messages` | Append message |
+| `GET` | `/chat/sessions/{session_id}/runs` | Local audit trail for session |
+| `POST` | `/chat/sessions/{session_id}/prepare` | Clarify and prepare dispatch |
+| `POST` | `/chat/sessions/{session_id}/execute` | Dispatch to GitHub agent or queue local pipeline |
 
 ---
 
@@ -417,35 +365,26 @@ Approves a specific task by ID.
 
 Available at `http://localhost:8080/dashboard`.
 
-Displays per-task:
-- Request title, body, and sender
-- Source (control) and target repository
-- Current task state and run status
-- PR draft title and opened PR link (once created)
-- Model used for the run
-- Polling mode and last poll timestamp
+Displays:
+
+- autonomy mode
+- polling status
+- model runtime
+- chat execution backend
+- task state
+- run status
+- delegated GitHub issue link when applicable
+- PR link when applicable
 
 ---
 
 ## Security Controls
 
-### Cross-Repo Path Leak Detection
-
-If the agent proposes edits to files belonging to the control/source repository instead of the target repository, the task is immediately failed with event `proposal_target_mismatch`. This prevents the agent from accidentally modifying its own codebase.
-
-### Bot Comment Filtering
-
-All comments from GitHub App bots (`[bot]` suffix or `type: Bot`) are skipped during polling to prevent infinite approval loops.
-
-### Policy Enforcement
-
-- `allow_any_target_repository: false` — explicit allowlist required
-- `approval_required_actions` — shell execution and PR merging always require human approval regardless of autonomy mode
-- `network_enabled: false` — sandbox network disabled by default
-
-### Webhook Security
-
-All incoming webhooks are validated with HMAC-SHA256 using `GITHUB_WEBHOOK_SECRET` before any processing.
+- `allow_any_target_repository: false` keeps target repos allowlisted by default
+- GitHub bot comments are ignored during polling to prevent feedback loops
+- webhook requests are HMAC-validated with `GITHUB_WEBHOOK_SECRET`
+- local local-pipeline path still checks for cross-repo path mismatch before PR creation
+- admin-protected routes can be gated with `API_ADMIN_TOKEN`
 
 ---
 
@@ -454,21 +393,22 @@ All incoming webhooks are validated with HMAC-SHA256 using `GITHUB_WEBHOOK_SECRE
 | Variable | Default | Description |
 |---|---|---|
 | `APP_ENV` | `development` | Environment name |
-| `API_ADMIN_TOKEN` | — | Optional admin token for privileged API routes |
+| `API_ADMIN_TOKEN` | — | Optional API/UI admin token |
 | `GITHUB_APP_ID` | — | GitHub App numeric ID |
 | `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for webhook verification |
-| `GITHUB_PRIVATE_KEY` | — | PEM private key (inline) |
-| `GITHUB_PRIVATE_KEY_PATH` | — | Path to PEM file (alternative to inline) |
+| `GITHUB_PRIVATE_KEY` | — | Inline PEM private key |
+| `GITHUB_PRIVATE_KEY_PATH` | — | Path to PEM private key |
 | `GITHUB_API_BASE_URL` | `https://api.github.com` | GitHub API base |
-| `GITHUB_MODELS_API_KEY` | — | Classic PAT with Copilot subscription |
+| `GITHUB_AGENT_USER_TOKEN` | — | User token used for GitHub coding-agent issue dispatch |
+| `GITHUB_MODELS_API_KEY` | — | GitHub Models API key for manager-model calls |
 | `GITHUB_MODELS_BASE_URL` | `https://models.inference.ai.azure.com` | GitHub Models endpoint |
-| `GITHUB_MODELS_CHAT_MODEL` | `gpt-4.1-mini` | Model name (override in .env) |
+| `GITHUB_MODELS_CHAT_MODEL` | `gpt-4.1-mini` | Default GitHub manager model |
 | `DATABASE_URL` | `postgresql+psycopg://...` | PostgreSQL connection string |
 | `REDIS_URL` | `redis://redis:6379/0` | Redis connection string |
-| `QUEUE_NAME` | `agentic:tasks` | Redis list key for task queue |
-| `OLLAMA_BASE_URL` | `http://ollama:11434` | Ollama endpoint (if enabled) |
-| `OLLAMA_CHAT_MODEL` | `llama3.1:8b` | Ollama model (if enabled) |
-| `MODEL_REQUEST_TIMEOUT_SECONDS` | `40.0` | Per-request LLM timeout |
+| `QUEUE_NAME` | `agentic:tasks` | Redis queue key |
+| `OLLAMA_BASE_URL` | `http://ollama:11434` | Ollama endpoint |
+| `OLLAMA_CHAT_MODEL` | `llama3.1:8b` | Default local manager model |
+| `MODEL_REQUEST_TIMEOUT_SECONDS` | `40.0` | Per-request model timeout |
 
 ---
 
@@ -477,31 +417,33 @@ All incoming webhooks are validated with HMAC-SHA256 using `GITHUB_WEBHOOK_SECRE
 ### Quick Start
 
 ```bash
-make bootstrap   # start stack + run migrations + self-check
-make test        # run pytest in container
-make logs        # stream all service logs
-make lint        # ruff linting
+make bootstrap
+make qa
 ```
 
-### Running Tests Locally
+### Validation
 
 ```bash
-pip install -e ".[dev]"
-python -m pytest tests/ -q
+make test-regression
+make smoke
+make qa
 ```
 
 ### Migrations
 
 ```bash
-make migrate                                      # apply pending migrations
-alembic revision --autogenerate -m "description" # generate new migration
+make migrate
+alembic revision --autogenerate -m "description"
 ```
 
-### Adding a New Agent
+### Product guidance
 
-1. Create `src/agentic_coder/agents/my_agent.py` with a result dataclass and agent class
-2. Accept `model: ModelProvider | None = None` in `__init__`
-3. Implement `_*_with_model()` and `_*_stub()` methods
-4. Add result field to `PipelineResult` dataclass in `orchestration/pipeline.py`
-5. Instantiate the agent in `TaskPipeline.__init__` passing `_model`
-6. Call it in `TaskPipeline.run()`
+The highest-leverage future work is now in:
+
+- stronger clarification and planning loops
+- richer product memory and cross-session context
+- better GitHub-agent dispatch tracking and status sync
+- multi-repo orchestration
+- policy-driven routing across GitHub agent, local models, and local execution
+
+The lowest-leverage future work is trying to outbuild GitHub's implementation engine inside this repo.

--- a/README.md
+++ b/README.md
@@ -1,223 +1,211 @@
 # Agentic Coder
 
-Agentic Coder is a local-first, GitHub-native agent orchestration service for turning remote requests into tracked engineering runs.
+Agentic Coder is a private AI engineering control plane.
 
-## Current status
+It gives you a remote `/chat` endpoint you control, lets you capture work from your phone or browser, clarifies the request, and then dispatches implementation to GitHub Copilot coding agent by default. It also keeps a local pipeline backend as a fallback for self-hosted execution.
 
-The current implementation includes:
+## Product direction
 
-- FastAPI control plane with health, readiness, dashboard, timeline, and self-check endpoints
-- PostgreSQL-backed tasks, runs, run events, transitions, polling cursors, chat sessions, and chat messages
-- Worker polling against a dedicated control repository with remote `/approve` and `/reject` handling
-- GitHub App integration for status comments, approval comments, branch creation, and draft PR opening
-- Chat control plane at `/chat` for remote operator-driven task intake
-- Automated regression, smoke, and CI coverage
+This repository is no longer best understood as "a replacement for GitHub's coding agent." The stronger design is:
 
-## Current execution scope
+- `Agentic Coder` as the manager and private command center
+- `GitHub Copilot coding agent` as the primary implementation worker
+- `local_pipeline` as a fallback backend for local-only execution
 
-The pipeline currently plans, retrieves context, reviews, generates validation commands, and drafts PR metadata.
+That gives you:
 
-- The current PR flow always creates a target-repo branch, commits `.agentic/runs/<run_id>.md`, and opens a draft PR
-- When the coding proposal includes concrete file contents, those files are written into the PR branch before the PR opens
-- If the proposal does not include concrete file contents, the PR remains artifact-only
-- Patch application is therefore present, but it is still limited by proposal quality and the current context window
+- a private endpoint over your own network or Tailscale
+- persistent chat memory, sessions, runs, and audit history
+- repository allowlists and policy control
+- model selection for clarification/planning
+- a clean handoff into GitHub-native issue, PR, and review flows
+
+## Current capabilities
+
+- FastAPI control plane with health, readiness, self-check, dashboard, and chat endpoints
+- PostgreSQL-backed tasks, runs, run events, transitions, poll cursors, chat sessions, and chat messages
+- Chat-first intake at `/chat`
+- Clarification and dispatch planning before execution
+- Default chat backend: `github_coding_agent`
+- Fallback chat backend: `local_pipeline`
+- GitHub App integration for repo access, polling, comments, branches, and PRs
+- GitHub-agent dispatch audit trail recorded locally as `delegated` tasks
+- GitHub comment workflow for control-repo task intake and remote approvals
+- Regression, smoke, and CI coverage
+
+## How it works
+
+### Default path: chat -> GitHub coding agent
+
+1. You open `/chat`.
+2. Create a session for an allowed target repository.
+3. Choose a manager model.
+4. Add one or more chat messages describing the work.
+5. Click `Analyze Request`.
+6. The chat manager either:
+   - marks the request ready, or
+   - asks clarification questions and stores them in the session transcript.
+7. Click `Dispatch To GitHub Agent` when the request is ready.
+8. Agentic Coder creates a GitHub issue in the target repository, assigns GitHub coding agent, and records a local task/run audit trail in state `delegated`.
+9. GitHub's coding agent performs the implementation work in GitHub's environment and opens the PR in the target repository.
+
+### Fallback path: chat -> local pipeline
+
+If `chat.execution_backend` is set to `local_pipeline`, the chat session creates a normal local task, queues it through Redis, and the local worker executes the current planning/coding/review/PR pipeline.
+
+That path still exists, but it is now the fallback mode rather than the default product direction.
+
+## Chat operating model
+
+The `/chat` UI is the main operator surface.
+
+Session inputs:
+
+- `Session Title`
+- `Target Repository`
+- `Base Branch`
+- `Custom Agent (optional)`
+- `Manager Model`
+- `Operator Identity`
+
+Session actions:
+
+- `Create Session`
+- `Analyze Request`
+- `Dispatch To GitHub Agent`
+- `Refresh`
+
+The manager model is used for clarification and dispatch planning.
+
+- GitHub-backed models are labeled with Copilot token cost tiers:
+  - `0x` means no premium Copilot token charge for that model choice
+  - `1x` means premium Copilot token charge for that model choice
+- `local` means the planning model runs through Ollama locally
+
+Important: those labels describe the manager model used by Agentic Coder for planning. When you dispatch to GitHub coding agent, GitHub's execution still carries its own cost model, including GitHub Actions minutes and Copilot premium requests.
+
+## Approvals and control
+
+### GitHub-agent backend
+
+For the default `github_coding_agent` backend:
+
+- clarification happens in `/chat` before dispatch
+- after dispatch, the implementation lifecycle is GitHub-native
+- code review, iteration, and merge happen in GitHub on the dispatched issue and resulting PR
+
+### Local pipeline backend
+
+For `local_pipeline` in `gated` mode:
+
+- you still approve remotely through GitHub issue comments
+- chat execution requires an `approval_issue_number`
+- the worker posts approval and status comments to the control repository issue
+- `/approve` and `/reject` comments drive state transitions
 
 ## Development workflow
 
-This project can be used without a local Python environment.
+This project is designed to run container-first.
 
-### Container-first development
+### Quick start
 
-Use Docker Compose as the primary development environment:
+- `make bootstrap`
+- `make qa`
 
-- `api`
-- `worker`
-- `executor`
-- `postgres`
-- `redis`
-- optional `ollama`
+Useful commands:
 
-Recommended workflow:
+- `make up`
+- `make down`
+- `make logs`
+- `make migrate`
+- `make test`
+- `make lint`
+- `make test-regression`
+- `make smoke`
+- `make qa`
+- `make shell`
 
-1. Open the repository in the provided dev container.
-2. Run services with Docker Compose.
-3. Execute tests and linting inside the container.
+The API is exposed on host port `8080`.
 
-Quick commands (default path):
+## Key configuration
 
-- `make up` start local stack
-- `make down` stop local stack
-- `make logs` stream service logs
-- `make migrate` run alembic migrations
-- `make bootstrap` start stack + migrate + run startup self-check
-- `make test` run pytest in container
-- `make lint` run ruff in container
-- `make test-regression` run lint + full pytest suite
-- `make smoke` run runtime smoke tests against live API container
-- `make qa` run regression + smoke end-to-end
-- `make shell` open shell in api container
+Primary product behavior is controlled in [agentic.yaml](agentic.yaml).
 
-Notes:
+Important sections:
 
-- API is exposed on host port `8080`.
-- Postgres and Redis are internal to the Compose network by default (prevents host port conflicts).
+```yaml
+system:
+  control_repository: owner/agentic_coder
+  allow_any_target_repository: false
+  allowed_target_repositories:
+    - owner/predictiv
 
-### Initial bootstrap
+autonomy:
+  mode: gated
 
-1. `make bootstrap`
-2. `make qa`
+chat:
+  execution_backend: github_coding_agent   # github_coding_agent | local_pipeline
+  auto_prepare: true
+```
 
-`make bootstrap` starts the stack, applies migrations, and runs the GitHub startup self-check. `make qa` then runs lint, tests, and live smoke validation.
+### Required environment variables
 
-### Operating the system
+For the default GitHub-agent flow:
 
-There are two supported operator paths:
+- `GITHUB_APP_ID`
+- `GITHUB_PRIVATE_KEY` or `GITHUB_PRIVATE_KEY_PATH`
+- `GITHUB_AGENT_USER_TOKEN`
+- `DATABASE_URL`
+- `REDIS_URL`
 
-- GitHub comment workflow: comment on the control repository with `@agent repo=...` or `/repo ...`
-- Chat workflow: open `http://localhost:8080/chat` and create a session for an allowed target repository
+Optional but common:
 
-Remote approvals remain GitHub-native in `gated` mode:
+- `API_ADMIN_TOKEN`
+- `GITHUB_WEBHOOK_SECRET`
+- `GITHUB_MODELS_API_KEY`
+- `GITHUB_MODELS_CHAT_MODEL`
+- `OLLAMA_BASE_URL`
+- `OLLAMA_CHAT_MODEL`
 
-- Comment `/approve` or `/approve <task_id>` on the control-repo issue thread
-- Comment `/reject <task_id> reason` or `/reject reason`
-- Chat executions in `gated` mode require an approval issue number so the worker knows where to post approval and status comments
-- The chat UI exposes a model dropdown sourced from the backend runtime, with cost labels:
-  - `0x`: no premium Copilot token charge
-  - `1x`: premium Copilot token charge
-  - `local`: local Ollama runtime
+`GITHUB_AGENT_USER_TOKEN` is the credential used to create the dispatched issue that assigns GitHub coding agent in the target repository.
 
-### GitHub PR workflow
+## Operational endpoints
 
-The API supports creating a draft PR from an existing run timeline:
-
-- `POST /runs/{run_id}/pull-request`
-- body: `{"installation_id": <int>, "branch_name": "agentic/<run>", "draft": true}`
-
-This flow uses GitHub App installation token exchange, resolves the repository default branch, creates the head branch, commits the run artifact, and opens a draft PR using run-generated PR draft metadata.
-When the run includes concrete `file_changes`, those files are committed to the branch before the run artifact is written.
-
-### Control repo vs target repos
-
-This agent can run from a dedicated control repository and execute development work in other repositories.
-
-- Default target repo: webhook source repo (`payload.repository.full_name`)
-- Explicit target override in issue/PR comment body:
-	- `repo=owner/name`
-	- `/repo owner/name`
-- Policy gate in [agentic.yaml](agentic.yaml):
-	- `system.allow_any_target_repository`
-	- `system.allowed_target_repositories`
-
-For production, keep `allow_any_target_repository: false` and explicitly list allowed targets.
-
-### Polling mode (private-by-default)
-
-The default trigger mode is polling, which means no public webhook endpoint is required.
-
-Design summary:
-
-- worker polls GitHub issue comments from `system.control_repository`
-- comments are converted into normalized tasks only when command syntax is present (`@agent`, `repo=...`, `/repo ...`)
-- target repos are constrained by `system.allowed_target_repositories`
-- polling cursor and poll-cycle metrics are durably stored in PostgreSQL (`poll_cursors`)
-
-- Trigger config in [agentic.yaml](agentic.yaml):
-	- `trigger.mode: polling|webhook|hybrid`
-	- `trigger.poll_interval_seconds`
-	- `trigger.max_items_per_poll`
-- Poll source repo:
-	- `system.control_repository`
-
-Polling currently ingests issue comments from the control repository and creates tasks for comments that include agent commands (`@agent`, `repo=...`, or `/repo ...`).
-
-Polling observability endpoint:
-
+- `GET /healthz`
+- `GET /readyz`
+- `GET /self-check`
+- `GET /startup/self-check`
 - `GET /polling/status`
-	- returns configured trigger mode/interval/max-items
-	- returns current cursor key and last poll metadata (`last_polled_at`, `last_seen_count`, `last_enqueued_count`, `since`, `last_comment_id`)
+- `GET /dashboard`
+- `GET /dashboard/data`
+- `GET /chat`
 
-Example:
+Chat API:
 
-- `curl http://localhost:8080/polling/status`
+- `POST /chat/sessions`
+- `GET /chat/sessions`
+- `GET /chat/sessions/{session_id}`
+- `GET /chat/sessions/{session_id}/messages`
+- `POST /chat/sessions/{session_id}/messages`
+- `GET /chat/sessions/{session_id}/runs`
+- `POST /chat/sessions/{session_id}/prepare`
+- `POST /chat/sessions/{session_id}/execute`
 
-### Where to configure model + repo targeting
+## What the dashboard shows
 
-Primary configuration is in [agentic.yaml](agentic.yaml):
+The dashboard tracks both local and delegated work.
 
-- `models.primary_provider`: current default is `github`
-- `models.fallback_provider`: fallback model path
-- `system.allow_any_target_repository`: broad target access toggle
-- `system.allowed_target_repositories`: explicit allowlist (supports `owner/repo` or bare repo name)
+For delegated GitHub-agent runs it now shows:
 
-Current defaults are configured to allow only `predictiv` as a target repository.
+- task state `delegated`
+- local run metadata
+- dispatched issue link
+- PR link when available from the tracked run history
 
-The current local environment is configured to use `Phi-4` via `GITHUB_MODELS_CHAT_MODEL`.
+## What remains true
 
-### Startup self-check
+- GitHub issue comment polling still works and is useful for control-repo workflows
+- the local worker and PR pipeline still exist
+- this repo still supports real file-changing PRs in the local pipeline when the proposal contains full file contents
 
-Startup GitHub integration validation is enabled by default.
-
-- `GET /startup/self-check` returns the last startup check result
-- `POST /startup/self-check/run` reruns checks on demand
-
-Checks include:
-
-- GitHub credential presence (`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, webhook secret)
-- GitHub App API access (`GET /app`)
-- Per-repository installation + default branch checks for configured control/target repos
-
-Environment flags:
-
-- `GITHUB_STARTUP_SELF_CHECK=true`
-- `GITHUB_STARTUP_SELF_CHECK_FAIL_FAST=false`
-
-Set fail-fast to `true` when deploying production workers that should not run with broken GitHub integration.
-
-### GitHub integration setup checklist
-
-1. Create a GitHub App in your org/user settings.
-2. Fill the required URL fields in GitHub App settings:
-	- Homepage URL: any valid URL you control (for local dev you can use your GitHub profile/repo URL)
-	- Webhook URL: public URL to this service endpoint `/github/webhook`
-	  - local dev requires a tunnel (for example `https://<subdomain>.ngrok.app/github/webhook`)
-	- Callback URL: only needed if you enable user-to-server OAuth flow; otherwise leave unset
-3. Set permissions:
-	- Metadata: Read
-	- Contents: Read & Write
-	- Pull requests: Read & Write
-	- Issues: Read & Write
-4. Enable webhook and set webhook secret.
-5. Copy values into runtime env:
-	- `GITHUB_APP_ID`
-	- `GITHUB_WEBHOOK_SECRET`
-	- choose one private key option:
-	  - `GITHUB_PRIVATE_KEY` (inline PEM value)
-	  - `GITHUB_PRIVATE_KEY_PATH` (path to PEM file mounted in container)
-6. Install the app on:
-	- your control repo
-	- `predictiv`
-7. Verify with:
-	- `GET /startup/self-check`
-	- `GET /polling/status`
-
-If you run polling mode only, webhook delivery is optional. You can still set `GITHUB_WEBHOOK_SECRET` now and switch to `trigger.mode: webhook` or `hybrid` later.
-
-If `make` is unavailable, use direct Compose commands:
-
-- `docker compose up --build -d`
-- `docker compose run --rm api pytest`
-- `docker compose run --rm api ruff check src tests scripts`
-- `docker compose run --rm -e BASE_URL=http://api:8080 api python scripts/smoke_test.py --base-url http://api:8080 --target-repository predictiv`
-
-The repository includes a `.devcontainer` configuration so VS Code can attach directly to the `api` service and use the container interpreter for analysis and testing.
-
-### Local Python environment
-
-A host Python environment is optional and only needed if container-based development is not desired.
-
-## Recommended next investments
-
-- Improve patch fidelity so the coding agent can reliably produce complete file updates for more than the current narrow context window
-- Execute generated validation commands in the sandbox executor before PR open
-- Reduce worker idle-log noise or make polling log verbosity configurable
-- Strengthen retrieval and knowledge-graph quality beyond the current `.py`-centric heuristics
+The difference is that the default product posture is now orchestration and control, not rebuilding GitHub's coding worker.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,83 +1,137 @@
-# Usage Guide: GitHub Comment and Chat Workflows
+# Usage Guide
+
+## Recommended workflow: remote chat to GitHub agent
+
+This is the primary way to use Agentic Coder now.
+
+1. Open `http://<host>:8080/chat`.
+2. If `API_ADMIN_TOKEN` is configured, enter it when prompted.
+3. Create a session with:
+   - a short session title
+   - an allowed target repository
+   - an optional base branch override
+   - an optional custom agent name
+   - a manager model
+4. Add one or more user messages describing the work.
+5. Click `Analyze Request`.
+6. If the session asks clarification questions, answer them in the chat and analyze again.
+7. Click `Dispatch To GitHub Agent` when the request is ready.
+8. Track the delegated issue and resulting PR in GitHub.
+9. Use `/dashboard` to see the local audit trail and dispatched issue links.
+
+## What the system actually does
+
+When you click `Analyze Request`:
+
+- the chat transcript is collected from PostgreSQL
+- the selected manager model is used for clarification and dispatch planning
+- the system decides whether the request is ready or needs more information
+- the result is written back into the session transcript as an assistant message
+
+When you click `Dispatch To GitHub Agent`:
+
+- Agentic Coder prepares a GitHub issue body from the transcript and planning summary
+- it creates a GitHub issue in the target repository
+- it assigns GitHub coding agent to that issue
+- it stores a local task and run so you keep a private audit trail
+- the local task moves to `delegated`
+
+The coding work itself then happens through GitHub's coding-agent workflow, not the local worker.
+
+## Model selection
+
+The chat UI exposes a live model catalog from the backend runtime.
+
+- `0x`: manager model does not consume premium Copilot token charge
+- `1x`: manager model consumes premium Copilot token charge
+- `local`: manager model runs through Ollama locally
+
+These labels only describe the manager model used by Agentic Coder for planning and clarification.
+
+If you dispatch to GitHub coding agent, GitHub execution still uses its own billing model.
+
+## Required setup for GitHub-agent dispatch
+
+You need all of the following:
+
+- GitHub App credentials configured for repo access
+- `GITHUB_AGENT_USER_TOKEN` configured in the runtime environment
+- target repository present in `allowed_target_repositories`
+- GitHub coding agent available for the target repository
+
+Recommended `.env` items:
+
+```dotenv
+GITHUB_APP_ID=...
+GITHUB_PRIVATE_KEY_PATH=/run/secrets/github_app_private_key.pem
+GITHUB_AGENT_USER_TOKEN=ghu_...
+GITHUB_MODELS_API_KEY=ghp_...
+API_ADMIN_TOKEN=replace-me-if-you-want-ui-protection
+```
+
+## Fallback workflow: local pipeline
+
+If you set this in `agentic.yaml`:
+
+```yaml
+chat:
+  execution_backend: local_pipeline
+```
+
+then `/chat` will queue a normal local task instead of delegating to GitHub coding agent.
+
+That path is still useful when:
+
+- you want local-only execution
+- you do not want to dispatch into GitHub's coding-agent environment
+- you are testing the local worker pipeline
+
+### Gated mode for local pipeline
+
+If `autonomy.mode` is `gated` and `chat.execution_backend` is `local_pipeline`:
+
+- set `approval_issue_number` on the chat session or execute payload
+- the worker will post approval comments to the control repository issue
+- approve with `/approve` or reject with `/reject`
 
 ## GitHub comment workflow
 
-1. Open an issue in the control repository: `italnstallion789/agentic_coder`.
-2. Add a request comment with an agent command, for example:
+The control repository flow still works.
 
-   ```text
-   @agent repo=italnstallion789/predictiv
-   Add a health-check endpoint and update the tests.
-   ```
+Example request comment:
 
-3. The worker polls the control repository, normalizes the request, stores the task in PostgreSQL, and enqueues it through Redis.
-4. Track progress through:
-   - `GET /tasks`
-   - `GET /tasks/{task_id}`
-   - `GET /tasks/{task_id}/timeline`
-   - `GET /dashboard`
+```text
+@agent repo=owner/repo
+Improve onboarding completion and add regression coverage.
+```
 
-## Remote approval workflow
-
-When `autonomy.mode` is `gated`, the run pauses at `awaiting_approval` after planning, proposal generation, review, security scan, and PR draft generation.
-
-Approve from the same control-repository issue thread with either:
+Approve in gated mode with:
 
 ```text
 /approve
 ```
 
-or:
+Reject with:
 
 ```text
-/approve <task_id>
+/reject needs a smaller scope
 ```
 
-Reject with either:
+This workflow is now secondary to the chat control plane, but it remains available.
 
-```text
-/reject reason here
-```
+## How to operate it remotely
 
-or:
+A practical remote setup looks like this:
 
-```text
-/reject <task_id> reason here
-```
+1. Run the stack on a machine you control.
+2. Expose that machine through Tailscale.
+3. Visit `/chat` and `/dashboard` from your phone.
+4. Use `/chat` as the command surface.
+5. Let GitHub handle implementation, PR creation, review, and merge on the repository side.
 
-After approval, the worker opens a draft PR in the target repository from an `agentic/<run>` branch.
+That gives you a private control plane without rebuilding GitHub's coding worker.
 
-## Chat control plane workflow
-
-The app also supports remote intake from `http://localhost:8080/chat`.
-
-1. Open `/chat`.
-2. If `API_ADMIN_TOKEN` is configured, enter it when prompted by the UI.
-3. Create a session for an allowed target repository and choose the execution model from the dropdown.
-4. Add one or more messages describing the work.
-5. In `gated` mode, set an approval issue number on the session or execution request.
-6. Execute the session to enqueue it as a normal task.
-
-The model dropdown is populated from the live backend runtime:
-
-- `0x` means no premium Copilot token charge
-- `1x` means premium Copilot token charge
-- `local` means the configured Ollama model
-
-Chat sessions are persisted in PostgreSQL and linked back to any tasks they create.
-
-## What the current PR contains
-
-The current implementation always writes a run artifact and may also write model-generated source edits into the target repository.
-
-- The branch contains a run artifact at `.agentic/runs/<run_id>.md`
-- If the coding proposal includes concrete `file_changes`, those files are committed into the PR branch before the artifact
-- The draft PR title/body come from the pipeline output
-- The proposal, target files, review result, and test plan are visible through task/run metadata
-
-This means the system can now open real file-changing PRs, but patch quality still depends on the coding proposal producing complete file contents from the retrieved context.
-
-## Operational endpoints
+## Useful endpoints
 
 - `GET /healthz`
 - `GET /readyz`

--- a/agentic.yaml
+++ b/agentic.yaml
@@ -69,3 +69,6 @@ budgets:
   max_prompt_tokens: 32000
   max_completion_tokens: 8000
   max_parallel_candidates: 1
+chat:
+  execution_backend: github_coding_agent
+  auto_prepare: true

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -166,6 +166,23 @@ def main() -> int:
     )
     require("tasks" in runs, f"runs payload missing tasks: {runs}")
 
+    print("[smoke] preparing chat dispatch plan")
+    _response, prepared = request_json(
+        "POST",
+        f"{base_url}/chat/sessions/{session_id}/prepare",
+        headers=headers,
+        payload={},
+    )
+    require(prepared.get("ok") is True, f"prepare payload missing ok=true: {prepared}")
+    require(
+        prepared.get("backend") in {"github_coding_agent", "local_pipeline"},
+        f"unexpected chat backend in prepare response: {prepared}",
+    )
+    require(
+        isinstance(prepared.get("summary"), str) and prepared.get("summary"),
+        f"prepare response missing summary: {prepared}",
+    )
+
     print("[smoke] all checks passed")
     return 0
 

--- a/src/agentic_coder/agents/chat_manager.py
+++ b/src/agentic_coder/agents/chat_manager.py
@@ -1,0 +1,125 @@
+import json
+from dataclasses import dataclass, field
+
+from agentic_coder.models.providers import ChatMessage, ModelProvider
+
+
+@dataclass(slots=True)
+class DispatchPlan:
+    ready: bool
+    summary: str
+    issue_title: str
+    issue_body_markdown: str
+    custom_instructions: str
+    clarification_questions: list[str] = field(default_factory=list)
+
+
+class ChatManagerAgent:
+    def __init__(self, model: ModelProvider | None = None) -> None:
+        self.model = model
+
+    async def prepare_dispatch(
+        self,
+        *,
+        session_title: str,
+        target_repository: str,
+        transcript: str,
+        base_branch: str,
+    ) -> DispatchPlan:
+        if self.model is not None:
+            try:
+                return await self._prepare_with_model(
+                    session_title=session_title,
+                    target_repository=target_repository,
+                    transcript=transcript,
+                    base_branch=base_branch,
+                )
+            except Exception:
+                pass
+        return self._prepare_stub(
+            session_title=session_title,
+            target_repository=target_repository,
+            transcript=transcript,
+            base_branch=base_branch,
+        )
+
+    def _prepare_stub(
+        self,
+        *,
+        session_title: str,
+        target_repository: str,
+        transcript: str,
+        base_branch: str,
+    ) -> DispatchPlan:
+        issue_title = (session_title or "Agentic request").strip()
+        body = (
+            "## Objective\n"
+            f"- Work on `{target_repository}` from `{base_branch}`.\n\n"
+            "## Transcript\n"
+            "```text\n"
+            f"{transcript.strip()}\n"
+            "```\n"
+        )
+        return DispatchPlan(
+            ready=True,
+            summary=f"Dispatch `{issue_title}` to GitHub coding agent.",
+            issue_title=issue_title,
+            issue_body_markdown=body,
+            custom_instructions="Follow the transcript, keep changes scoped, and open a draft PR.",
+            clarification_questions=[],
+        )
+
+    async def _prepare_with_model(
+        self,
+        *,
+        session_title: str,
+        target_repository: str,
+        transcript: str,
+        base_branch: str,
+    ) -> DispatchPlan:
+        prompt = (
+            "You are an engineering manager preparing work for GitHub Copilot coding agent.\n"
+            "Given a chat transcript, decide if the request is ready to dispatch or if the user "
+            "must answer clarification questions first.\n"
+            "Return ONLY compact JSON with keys:\n"
+            "  - ready (boolean)\n"
+            "  - summary (string)\n"
+            "  - issue_title (string)\n"
+            "  - issue_body_markdown (string)\n"
+            "  - custom_instructions (string)\n"
+            "  - clarification_questions (array of strings, max 3)\n"
+            "Rules:\n"
+            "  - If the request is ambiguous or missing decision-making context, set ready=false.\n"
+            "  - Ask only the minimum questions needed to unblock the work.\n"
+            "  - If ready=true, issue_body_markdown must include sections titled Objective, "
+            "Context, Constraints, and Acceptance Criteria.\n"
+            "  - custom_instructions should be short operational guidance for the coding agent.\n\n"
+            f"Session title: {session_title or 'Untitled'}\n"
+            f"Target repository: {target_repository}\n"
+            f"Base branch: {base_branch}\n\n"
+            f"Transcript:\n{transcript}\n"
+        )
+        messages = [
+            ChatMessage(
+                role="system",
+                content=(
+                    "You are an engineering manager. Respond only with valid JSON and be precise."
+                ),
+            ),
+            ChatMessage(role="user", content=prompt),
+        ]
+        response = await self.model.chat(messages)
+        parsed = json.loads(response)
+        questions = [
+            str(item).strip()
+            for item in (parsed.get("clarification_questions") or [])
+            if str(item).strip()
+        ][:3]
+        return DispatchPlan(
+            ready=bool(parsed.get("ready", True)),
+            summary=str(parsed.get("summary") or session_title or "Dispatch request"),
+            issue_title=str(parsed.get("issue_title") or session_title or "Agentic request"),
+            issue_body_markdown=str(parsed.get("issue_body_markdown") or transcript),
+            custom_instructions=str(parsed.get("custom_instructions") or ""),
+            clarification_questions=questions,
+        )

--- a/src/agentic_coder/api/chat.html
+++ b/src/agentic_coder/api/chat.html
@@ -206,6 +206,7 @@
     }
 
     .state-awaiting_approval { color: var(--warn); }
+    .state-delegated { color: var(--accent-2); }
     .state-succeeded { color: var(--ok); }
     .state-failed, .state-cancelled { color: var(--danger); }
 
@@ -224,7 +225,7 @@
     <section class="card panel">
       <div class="stack">
         <h1 class="title">Chat Control Plane</h1>
-        <p class="sub">Enterprise intake with persistent sessions and execution traceability.</p>
+        <p class="sub">Private engineering manager for clarifying work and dispatching it to GitHub coding agent.</p>
       </div>
 
       <div class="stack">
@@ -236,13 +237,17 @@
         <input class="input mono" id="sessionRepo" placeholder="owner/repo or repo" />
       </div>
       <div class="stack">
-        <label class="sub" for="sessionApprovalIssue">Approval Issue # (optional)</label>
-        <input class="input mono" id="sessionApprovalIssue" placeholder="123" />
+        <label class="sub" for="sessionBaseBranch">Base Branch</label>
+        <input class="input mono" id="sessionBaseBranch" placeholder="develop" />
       </div>
       <div class="stack">
-        <label class="sub" for="sessionModel">Execution Model</label>
+        <label class="sub" for="sessionCustomAgent">Custom Agent (optional)</label>
+        <input class="input mono" id="sessionCustomAgent" placeholder="frontend-designer" />
+      </div>
+      <div class="stack">
+        <label class="sub" for="sessionModel">Manager Model</label>
         <select class="select" id="sessionModel"></select>
-        <div class="sub" id="modelLegend">Select the model and cost tier for this chat run.</div>
+        <div class="sub" id="modelLegend">Used for clarification and planning. GitHub-backed models are also forwarded to GitHub agent when supported.</div>
       </div>
       <div class="stack">
         <label class="sub" for="operatorId">Operator Identity</label>
@@ -263,7 +268,8 @@
           <p class="sub mono" id="activeMeta">session: —</p>
         </div>
         <div class="row">
-          <button class="btn warn" id="executeBtn">Execute To Branch + PR</button>
+          <button class="btn ghost" id="prepareBtn">Analyze Request</button>
+          <button class="btn warn" id="executeBtn">Dispatch To GitHub Agent</button>
           <button class="btn ghost" id="refreshActiveBtn">Refresh</button>
           <span class="status-pill" id="executionStatus">idle</span>
         </div>
@@ -352,6 +358,10 @@
       return provider || "unknown";
     }
 
+    function executionBackend() {
+      return window.AGENTIC_CHAT_CONFIG?.executionBackend || "github_coding_agent";
+    }
+
     function modelOptionLabel(option) {
       const label = `${providerLabel(option.provider)} - ${option.displayName} (${option.costTier})`;
       return option.recommended ? `${label} - recommended` : label;
@@ -403,7 +413,10 @@
       }
       const costMeaning =
         window.AGENTIC_CHAT_CONFIG?.costLegend?.[selected.costTier] || "Configured model tier";
-      legend.textContent = `${providerLabel(selected.provider)} / ${selected.displayName} - ${selected.costTier}: ${costMeaning}`;
+      const forwarded = selected.provider === "github"
+        ? "Forwarded to GitHub coding agent when supported."
+        : "Used locally for planning; GitHub agent uses its default model."
+      legend.textContent = `${providerLabel(selected.provider)} / ${selected.displayName} - ${selected.costTier}: ${costMeaning}. ${forwarded}`;
     }
 
     async function api(path, options = {}) {
@@ -451,7 +464,8 @@
             <button class="session-item ${active}" data-session-id="${session.session_id}">
               <div><strong>${escapeHtml(session.title)}</strong></div>
               <div class="mono sub">${escapeHtml(session.target_repository)}</div>
-              <div class="sub">approval issue: ${escapeHtml(session.approval_issue_number || "none")}</div>
+              <div class="sub">base: ${escapeHtml(session.base_branch || "default")}</div>
+              <div class="sub">custom agent: ${escapeHtml(session.custom_agent || "default")}</div>
               <div class="sub">model: ${escapeHtml(session.selected_model?.displayName || "default")} (${escapeHtml(session.selected_model?.costTier || "-")})</div>
               <div class="sub">updated ${new Date(session.updated_at).toLocaleString()}</div>
             </button>
@@ -477,13 +491,12 @@
         return;
       }
       titleEl.textContent = session.title;
-      const approval = session.approval_issue_number
-        ? ` • approval issue: #${session.approval_issue_number}`
-        : "";
+      const base = session.base_branch ? ` • base: ${session.base_branch}` : "";
+      const customAgent = session.custom_agent ? ` • agent: ${session.custom_agent}` : "";
       const model = session.selected_model
         ? ` • model: ${session.selected_model.displayName} (${session.selected_model.costTier})`
         : "";
-      metaEl.textContent = `session: ${session.session_id} • repo: ${session.target_repository}${approval}${model}`;
+      metaEl.textContent = `session: ${session.session_id} • repo: ${session.target_repository}${base}${customAgent}${model}`;
     }
 
     function renderMessages(messages) {
@@ -512,8 +525,12 @@
       root.innerHTML = tasks
         .map((task) => {
           const pr = task.pull_request || {};
+          const dispatch = task.dispatch || {};
           const prLink = pr.url
             ? `<a href="${escapeHtml(pr.url)}" target="_blank" rel="noopener">PR #${escapeHtml(pr.number)}</a>`
+            : "none";
+          const issueLink = dispatch.issue_url
+            ? `<a href="${escapeHtml(dispatch.issue_url)}" target="_blank" rel="noopener">Issue #${escapeHtml(dispatch.issue_number)}</a>`
             : "none";
           return `
             <div class="run-item">
@@ -522,6 +539,7 @@
               <div class="state-${escapeHtml(task.state)}">state: ${escapeHtml(task.state)}</div>
               <div>run: ${escapeHtml(task.run?.run_id || "n/a")} (${escapeHtml(task.run?.status || "n/a")})</div>
               <div>model: ${escapeHtml(task.run?.model_used || "n/a")}</div>
+              <div>dispatch: ${issueLink}</div>
               <div>pr: ${prLink}</div>
             </div>
           `;
@@ -551,7 +569,8 @@
       const session = activeSession();
       renderActiveHeader();
       if (!session) return;
-      document.getElementById("sessionApprovalIssue").value = session.approval_issue_number || "";
+      document.getElementById("sessionBaseBranch").value = session.base_branch || "";
+      document.getElementById("sessionCustomAgent").value = session.custom_agent || "";
       syncModelSelector(session.selected_model?.selectionKey || null);
       setStatus("loading active");
       const [messagesData, runsData] = await Promise.all([
@@ -566,14 +585,10 @@
     async function createSession() {
       const title = document.getElementById("sessionTitle").value.trim();
       const targetRepository = document.getElementById("sessionRepo").value.trim();
-      const approvalIssueRaw = document.getElementById("sessionApprovalIssue").value.trim();
-      const approvalIssue = approvalIssueRaw ? Number.parseInt(approvalIssueRaw, 10) : null;
+      const baseBranch = document.getElementById("sessionBaseBranch").value.trim();
+      const customAgent = document.getElementById("sessionCustomAgent").value.trim();
       if (!title || !targetRepository) {
         window.alert("Session title and target repository are required.");
-        return;
-      }
-      if (approvalIssueRaw && (!Number.isInteger(approvalIssue) || approvalIssue <= 0)) {
-        window.alert("Approval issue must be a positive integer.");
         return;
       }
       const selectedModel = selectedModelOption();
@@ -583,7 +598,8 @@
         body: JSON.stringify({
           title,
           target_repository: targetRepository,
-          approval_issue_number: approvalIssue,
+          base_branch: baseBranch || null,
+          custom_agent: customAgent || null,
           model_provider: selectedModel?.provider || null,
           model_name: selectedModel?.model || null,
         }),
@@ -616,29 +632,58 @@
       await refreshActiveSession();
     }
 
+    async function prepareSession() {
+      const session = activeSession();
+      if (!session) {
+        window.alert("Select a session first.");
+        return;
+      }
+      const selectedModel = selectedModelOption();
+      const baseBranch = document.getElementById("sessionBaseBranch").value.trim();
+      const customAgent = document.getElementById("sessionCustomAgent").value.trim();
+      setStatus("analyzing");
+      const result = await api(`/chat/sessions/${session.session_id}/prepare`, {
+        method: "POST",
+        body: JSON.stringify({
+          base_branch: baseBranch || null,
+          custom_agent: customAgent || null,
+          model_provider: selectedModel?.provider || null,
+          model_name: selectedModel?.model || null,
+        }),
+      });
+      setStatus(result.ready ? "ready to dispatch" : "needs clarification");
+      await refreshSessions();
+      await refreshActiveSession();
+    }
+
     async function executeSession() {
       const session = activeSession();
       if (!session) {
         window.alert("Select a session first.");
         return;
       }
-      const approvalIssueRaw = document.getElementById("sessionApprovalIssue").value.trim();
-      const approvalIssue = approvalIssueRaw ? Number.parseInt(approvalIssueRaw, 10) : null;
-      if (approvalIssueRaw && (!Number.isInteger(approvalIssue) || approvalIssue <= 0)) {
-        window.alert("Approval issue must be a positive integer.");
-        return;
-      }
       const selectedModel = selectedModelOption();
+      const baseBranch = document.getElementById("sessionBaseBranch").value.trim();
+      const customAgent = document.getElementById("sessionCustomAgent").value.trim();
       setStatus("executing");
       const result = await api(`/chat/sessions/${session.session_id}/execute`, {
         method: "POST",
         body: JSON.stringify({
-          approval_issue_number: approvalIssue,
+          base_branch: baseBranch || null,
+          custom_agent: customAgent || null,
           model_provider: selectedModel?.provider || null,
           model_name: selectedModel?.model || null,
         }),
       });
-      setStatus(result.reused ? "reused active task" : "execution enqueued");
+      if (result.clarification_required) {
+        setStatus("needs clarification");
+      } else if (result.dispatched) {
+        setStatus("dispatched to GitHub");
+      } else if (result.reused) {
+        setStatus("reused active task");
+      } else {
+        setStatus("execution complete");
+      }
       await refreshSessions();
       await refreshActiveSession();
     }
@@ -673,6 +718,13 @@
       });
     });
 
+    document.getElementById("prepareBtn").addEventListener("click", () => {
+      prepareSession().catch((error) => {
+        setStatus("error");
+        window.alert(error.message);
+      });
+    });
+
     document.getElementById("executeBtn").addEventListener("click", () => {
       executeSession().catch((error) => {
         setStatus("error");
@@ -687,6 +739,10 @@
     document.getElementById("sessionModel").addEventListener("change", () => {
       updateModelLegend();
     });
+
+    if (executionBackend() === "local_pipeline") {
+      document.getElementById("executeBtn").textContent = "Execute Local Pipeline";
+    }
 
     ensureOperator();
     syncModelSelector();

--- a/src/agentic_coder/api/dashboard.html
+++ b/src/agentic_coder/api/dashboard.html
@@ -83,7 +83,7 @@
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(5, minmax(0, 1fr));
       gap: 10px;
       margin-bottom: 12px;
     }
@@ -143,6 +143,12 @@
       color: var(--warn);
     }
 
+    .state-delegated {
+      background: #edf3ff;
+      border-color: #cadeff;
+      color: var(--accent);
+    }
+
     .state-succeeded {
       background: #e9f8ef;
       border-color: #c7ead3;
@@ -192,6 +198,7 @@
       <select id="stateFilter">
         <option value="">All states</option>
         <option value="awaiting_approval">Awaiting approval</option>
+        <option value="delegated">Delegated</option>
         <option value="ready">Ready</option>
         <option value="succeeded">Succeeded</option>
         <option value="failed">Failed</option>
@@ -232,6 +239,10 @@
       <div class="card">
         <div class="label">Embedding Provider</div>
         <div class="value" id="embeddingProvider">-</div>
+      </div>
+      <div class="card">
+        <div class="label">Chat Backend</div>
+        <div class="value" id="chatBackend">-</div>
       </div>
     </div>
 
@@ -325,6 +336,8 @@
         data.model?.fallback_provider || "-";
       document.getElementById("embeddingProvider").textContent =
         data.model?.embedding_provider || "-";
+      document.getElementById("chatBackend").textContent =
+        data.chat_execution_backend || "-";
 
       const search = (document.getElementById("searchInput").value || "").toLowerCase();
       const stateFilter = document.getElementById("stateFilter").value || "";
@@ -355,6 +368,7 @@
           const req = item.request || {};
           const run = item.run || {};
           const pr = item.pull_request || null;
+          const dispatch = item.dispatch || null;
           const issueNumber = req.issue_number ? `#${req.issue_number}` : "-";
           const body = esc((req.body || "").slice(0, 160));
           const taskId = esc(item.task_id);
@@ -365,6 +379,10 @@
             ? `<a href="${esc(pr.url)}" target="_blank" ` +
               `rel="noreferrer">PR #${esc(pr.number)}</a>`
             : '<span class="muted">None</span>';
+          const dispatchHtml = dispatch?.issue_url
+            ? `<div><a href="${esc(dispatch.issue_url)}" target="_blank" rel="noreferrer">Issue #${esc(dispatch.issue_number)}</a></div>
+               <div class="muted">${esc(dispatch.repository || "")}</div>`
+            : '<div class="muted">No delegated issue</div>';
           const actions = item.state === "awaiting_approval"
             ? `<div class="actions">
                 <button class="btn warn" onclick="approveTask('${taskId}')">Approve</button>
@@ -393,6 +411,7 @@
               <div class="muted">${esc(run.status || "-")}</div>
               <div class="muted">${esc(run.pr_draft_title || "")}</div>
               <div class="muted">model: ${esc(run.model_used || data.model?.primary_provider || "-")}</div>
+              ${dispatchHtml}
             </td>
             <td>${prHtml}</td>
             <td>${actions}</td>

--- a/src/agentic_coder/api/main.py
+++ b/src/agentic_coder/api/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import re
 from contextlib import asynccontextmanager
@@ -11,6 +12,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from agentic_coder.agents.chat_manager import ChatManagerAgent, DispatchPlan
 from agentic_coder.config import get_settings
 from agentic_coder.db.repositories import TaskRepository
 from agentic_coder.db.session import create_session_factory
@@ -22,6 +24,7 @@ from agentic_coder.models.catalog import (
     default_chat_model_selection,
     find_chat_model_option,
 )
+from agentic_coder.models.providers import GitHubHostedProvider, ModelProvider, OllamaProvider
 from agentic_coder.policy.loader import PolicyLoader, resolve_policy_path
 from agentic_coder.pull_requests import apply_pull_request_changes, extract_proposed_file_changes
 from agentic_coder.queue.redis_queue import RedisTaskQueue
@@ -92,6 +95,8 @@ class CreateChatSessionRequest(BaseModel):
     title: str = Field(min_length=1, max_length=256)
     target_repository: str = Field(min_length=1, max_length=256)
     approval_issue_number: int | None = Field(default=None, ge=1)
+    base_branch: str | None = Field(default=None, min_length=1, max_length=256)
+    custom_agent: str | None = Field(default=None, min_length=1, max_length=256)
     model_provider: Literal["github", "ollama"] | None = None
     model_name: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: dict[str, object] = Field(default_factory=dict)
@@ -109,6 +114,17 @@ class ExecuteChatSessionRequest(BaseModel):
     include_transcript_limit: int = Field(default=40, ge=1, le=200)
     force_new: bool = False
     approval_issue_number: int | None = Field(default=None, ge=1)
+    base_branch: str | None = Field(default=None, min_length=1, max_length=256)
+    custom_agent: str | None = Field(default=None, min_length=1, max_length=256)
+    model_provider: Literal["github", "ollama"] | None = None
+    model_name: str | None = Field(default=None, min_length=1, max_length=256)
+
+
+class PrepareChatSessionRequest(BaseModel):
+    include_transcript_limit: int = Field(default=40, ge=1, le=200)
+    target_repository: str | None = Field(default=None, max_length=256)
+    base_branch: str | None = Field(default=None, min_length=1, max_length=256)
+    custom_agent: str | None = Field(default=None, min_length=1, max_length=256)
     model_provider: Literal["github", "ollama"] | None = None
     model_name: str | None = Field(default=None, min_length=1, max_length=256)
 
@@ -241,6 +257,8 @@ def serialize_chat_session_response(
     return {
         **chat_session,
         "approval_issue_number": parse_positive_int(metadata.get("approval_issue_number")),
+        "base_branch": str(metadata.get("base_branch") or "").strip() or None,
+        "custom_agent": str(metadata.get("custom_agent") or "").strip() or None,
         "selected_model": serialize_chat_model_selection(
             settings=settings,
             metadata=metadata,
@@ -249,6 +267,73 @@ def serialize_chat_session_response(
         "created_at": chat_session["created_at"].isoformat(),
         "updated_at": chat_session["updated_at"].isoformat(),
     }
+
+
+def resolve_chat_execution_backend(policy: object) -> str:
+    chat_policy = getattr(policy, "chat", None)
+    return str(getattr(chat_policy, "execution_backend", "github_coding_agent") or "")
+
+
+def build_chat_manager_provider(
+    *,
+    settings: object,
+    selection: dict[str, object] | None,
+) -> ModelProvider | None:
+    selected_provider = str((selection or {}).get("provider") or "").strip()
+    selected_model = str((selection or {}).get("model") or "").strip()
+    if selected_provider == "github":
+        if not getattr(settings, "github_models_api_key", ""):
+            return None
+        return GitHubHostedProvider(
+            api_key=settings.github_models_api_key,
+            model=selected_model or settings.github_models_chat_model,
+            base_url=settings.github_models_base_url,
+            timeout_seconds=settings.model_request_timeout_seconds,
+        )
+    if selected_provider == "ollama":
+        return OllamaProvider(
+            model=selected_model or settings.ollama_chat_model,
+            base_url=settings.ollama_base_url,
+            timeout_seconds=settings.model_request_timeout_seconds,
+        )
+    return None
+
+
+def build_dispatch_question_message(plan: DispatchPlan) -> str:
+    questions = "\n".join(f"- {item}" for item in plan.clarification_questions)
+    return (
+        "I need a bit more direction before I dispatch this to GitHub coding agent.\n\n"
+        f"{questions}"
+    )
+
+
+def build_dispatch_ready_message(
+    *,
+    plan: DispatchPlan,
+    target_repository: str,
+    base_branch: str,
+    selected_model: dict[str, object] | None,
+) -> str:
+    lines = [
+        f"Ready to dispatch to GitHub coding agent for `{target_repository}`.",
+        f"Base branch: `{base_branch}`.",
+        f"Summary: {plan.summary}",
+    ]
+    if selected_model is not None:
+        lines.append(
+            "Manager model: "
+            f"{selected_model.get('displayName')} ({selected_model.get('costTier')})."
+        )
+        if selected_model.get("provider") == "github":
+            lines.append(
+                "This GitHub-backed model selection will also be forwarded to the coding agent."
+            )
+        else:
+            lines.append(
+                "This local model is used for planning/clarification; GitHub agent will use its "
+                "default execution model."
+            )
+    return "\n".join(lines)
 
 
 def build_chat_transcript(
@@ -265,6 +350,280 @@ def build_chat_transcript(
             continue
         lines.append(f"[{role}] {content}")
     return "\n".join(lines)
+
+
+def build_github_agent_issue_body(
+    *,
+    transcript: str,
+    prepared_body: str,
+    target_repository: str,
+    base_branch: str,
+) -> str:
+    sections = [prepared_body.strip()]
+    sections.append(
+        "## Dispatch Metadata\n"
+        f"- Target repository: `{target_repository}`\n"
+        f"- Base branch: `{base_branch}`\n"
+    )
+    sections.append(f"## Chat Transcript\n```text\n{transcript.strip()}\n```")
+    return "\n\n".join(section for section in sections if section.strip())
+
+
+def build_chat_dispatch_payload(
+    *,
+    session_id: str,
+    task_title: str,
+    transcript: str,
+    operator: str,
+    target_repository: str,
+    source_repository: str,
+    base_branch: str,
+    selected_model: dict[str, object] | None,
+    dispatch_plan: DispatchPlan,
+    issue_number: int,
+    issue_url: str,
+    issue_labels: list[str],
+) -> dict[str, object]:
+    return {
+        "event_name": "chat_github_agent_dispatch",
+        "source_repository": source_repository or "chat-ui",
+        "repository": target_repository,
+        "title": task_title,
+        "body": transcript,
+        "sender": operator,
+        "chat_session_id": session_id,
+        "chat_message_count": len(transcript.splitlines()),
+        "requested_at": datetime.now(UTC).isoformat(),
+        "dispatch_backend": "github_coding_agent",
+        "dispatch_issue_number": issue_number,
+        "dispatch_issue_url": issue_url,
+        "dispatch_base_branch": base_branch,
+        "dispatch_summary": dispatch_plan.summary,
+        "dispatch_labels": issue_labels,
+        "dispatch_model": (selected_model or {}).get("model"),
+        "dispatch_model_provider": (selected_model or {}).get("provider"),
+        "dispatch_model_cost_tier": (selected_model or {}).get("costTier"),
+    }
+
+
+def create_dispatch_audit_record(
+    *,
+    repo: TaskRepository,
+    task_title: str,
+    payload: dict[str, object],
+    dispatch_plan: DispatchPlan,
+    issue_number: int,
+    issue_url: str,
+    target_repository: str,
+    base_branch: str,
+    selected_model: dict[str, object] | None,
+) -> tuple[str, str]:
+    task = repo.create(title=task_title, payload=payload)
+    run_id = repo.create_run(task.task_id, worker_name="github-coding-agent-dispatch")
+    repo.update_state(
+        task.task_id,
+        TaskState.NORMALIZED,
+        run_id=run_id,
+        reason="chat_dispatch_normalized",
+    )
+    repo.update_state(
+        task.task_id,
+        TaskState.PLANNED,
+        run_id=run_id,
+        reason="chat_dispatch_prepared",
+    )
+    repo.update_state(
+        task.task_id,
+        TaskState.RUNNING,
+        run_id=run_id,
+        reason="chat_dispatch_running",
+    )
+    repo.append_run_event(
+        run_id,
+        "dispatch_prepared",
+        {
+            "summary": dispatch_plan.summary,
+            "issue_title": dispatch_plan.issue_title,
+            "clarification_questions": dispatch_plan.clarification_questions,
+        },
+    )
+    repo.append_run_event(
+        run_id,
+        "github_agent_issue_created",
+        {
+            "issue_number": issue_number,
+            "issue_url": issue_url,
+            "repository": target_repository,
+        },
+    )
+    repo.append_run_event(
+        run_id,
+        "github_agent_dispatched",
+        {
+            "repository": target_repository,
+            "issue_number": issue_number,
+            "issue_url": issue_url,
+            "base_branch": base_branch,
+            "model": (selected_model or {}).get("model"),
+            "model_provider": (selected_model or {}).get("provider"),
+            "model_cost_tier": (selected_model or {}).get("costTier"),
+        },
+    )
+    repo.update_run_metadata(
+        run_id,
+        {
+            "dispatch_backend": "github_coding_agent",
+            "dispatch_issue_number": issue_number,
+            "dispatch_issue_url": issue_url,
+            "dispatch_summary": dispatch_plan.summary,
+            "model_used": (
+                f"{selected_model['provider']}:{selected_model['model']}"
+                if selected_model is not None
+                else None
+            ),
+        },
+    )
+    repo.update_state(
+        task.task_id,
+        TaskState.DELEGATED,
+        run_id=run_id,
+        reason="github_coding_agent_dispatched",
+        details={
+            "issue_number": issue_number,
+            "issue_url": issue_url,
+            "repository": target_repository,
+        },
+    )
+    repo.complete_run(run_id, status="succeeded")
+    return task.task_id, run_id
+
+
+async def prepare_chat_dispatch_plan(
+    *,
+    session_id: str,
+    request_body: PrepareChatSessionRequest | ExecuteChatSessionRequest,
+    persist_message: bool,
+) -> dict[str, object]:
+    settings = get_settings()
+    _, policy = load_policy()
+    session_factory = create_session_factory()
+
+    with session_factory() as session:
+        repo = TaskRepository(session)
+        chat_session = repo.get_chat_session(session_id)
+        if chat_session is None:
+            raise HTTPException(status_code=404, detail="Chat session not found")
+
+        target_repository = str(
+            request_body.target_repository or chat_session["target_repository"]
+        ).strip()
+        if not target_repository:
+            raise HTTPException(status_code=400, detail="Target repository is required")
+
+        target_repository = expand_target_repository(policy, target_repository)
+        if not is_target_repository_allowed(policy, target_repository):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Target repository not allowed: {target_repository}",
+            )
+
+        messages = repo.list_chat_messages(
+            session_id=session_id,
+            limit=request_body.include_transcript_limit,
+        )
+        if not messages:
+            raise HTTPException(status_code=400, detail="Chat session has no messages")
+
+    metadata = dict(chat_session.get("metadata") or {})
+    selected_model = validate_chat_model_selection(
+        settings=settings,
+        provider=request_body.model_provider,
+        model=request_body.model_name,
+    ) or serialize_chat_model_selection(
+        settings=settings,
+        metadata=metadata,
+        policy=policy,
+    )
+    if selected_model is not None:
+        metadata["model_selection"] = {
+            "provider": selected_model["provider"],
+            "model": selected_model["model"],
+        }
+
+    base_branch = str(
+        request_body.base_branch
+        or metadata.get("base_branch")
+        or resolve_base_branch_for_repository(policy, target_repository)
+    ).strip()
+    custom_agent = str(request_body.custom_agent or metadata.get("custom_agent") or "").strip()
+    metadata["base_branch"] = base_branch
+    if custom_agent:
+        metadata["custom_agent"] = custom_agent
+    elif "custom_agent" in metadata:
+        metadata.pop("custom_agent", None)
+
+    transcript = build_chat_transcript(
+        messages,
+        limit=request_body.include_transcript_limit,
+    )
+    model_provider = build_chat_manager_provider(settings=settings, selection=selected_model)
+    manager = ChatManagerAgent(model=model_provider)
+    plan_result = manager.prepare_dispatch(
+        session_title=str(chat_session.get("title") or "Chat execution"),
+        target_repository=target_repository,
+        transcript=transcript,
+        base_branch=base_branch,
+    )
+    plan = await plan_result if inspect.isawaitable(plan_result) else plan_result
+
+    metadata["last_dispatch_plan"] = {
+        "ready": plan.ready,
+        "summary": plan.summary,
+        "issue_title": plan.issue_title,
+        "custom_instructions": plan.custom_instructions,
+        "clarification_questions": plan.clarification_questions,
+        "prepared_at": datetime.now(UTC).isoformat(),
+    }
+
+    with session_factory() as session:
+        repo = TaskRepository(session)
+        repo.update_chat_session_metadata(session_id=session_id, metadata=metadata)
+        if persist_message:
+            repo.append_chat_message(
+                session_id=session_id,
+                role="assistant",
+                content=(
+                    build_dispatch_ready_message(
+                        plan=plan,
+                        target_repository=target_repository,
+                        base_branch=base_branch,
+                        selected_model=selected_model,
+                    )
+                    if plan.ready
+                    else build_dispatch_question_message(plan)
+                ),
+                metadata={
+                    "kind": "dispatch_prepare",
+                    "ready": plan.ready,
+                    "clarification_questions": plan.clarification_questions,
+                    "target_repository": target_repository,
+                    "base_branch": base_branch,
+                    "selected_model": selected_model,
+                    "custom_agent": custom_agent or None,
+                },
+            )
+
+    return {
+        "chat_session": chat_session,
+        "metadata": metadata,
+        "target_repository": target_repository,
+        "base_branch": base_branch,
+        "custom_agent": custom_agent or None,
+        "selected_model": selected_model,
+        "transcript": transcript,
+        "plan": plan,
+        "policy": policy,
+    }
 
 
 async def resolve_repository_installation_id(repository: str) -> int:
@@ -308,6 +667,25 @@ def _extract_pull_request(events: list[dict[str, object]]) -> dict[str, object] 
         "branch": payload.get("branch_name"),
         "base": payload.get("base_branch"),
         "commit_sha": payload.get("commit_sha"),
+    }
+
+
+def _extract_dispatch_issue(events: list[dict[str, object]]) -> dict[str, object] | None:
+    dispatch_event = next(
+        (event for event in reversed(events) if event["event_type"] == "github_agent_dispatched"),
+        None,
+    )
+    if dispatch_event is None:
+        return None
+    payload = dispatch_event["payload"]
+    return {
+        "repository": payload.get("repository"),
+        "issue_number": payload.get("issue_number"),
+        "issue_url": payload.get("issue_url"),
+        "base_branch": payload.get("base_branch"),
+        "model": payload.get("model"),
+        "model_provider": payload.get("model_provider"),
+        "model_cost_tier": payload.get("model_cost_tier"),
     }
 
 
@@ -361,6 +739,7 @@ def _build_dashboard_task_view(
             "pr_draft_title": ((pr_draft_event or {}).get("payload") or {}).get("title"),
             "model_used": ((latest_run or {}).get("metadata") or {}).get("model_used"),
         },
+        "dispatch": _extract_dispatch_issue(run_events),
         "pull_request": _extract_pull_request(run_events),
     }
 
@@ -413,6 +792,13 @@ async def run_github_self_check() -> SelfCheckResponse:
             "app_id_set": bool(settings.github_app_id),
             "private_key_set": bool(settings.github_private_key),
             "webhook_secret_set": bool(settings.github_webhook_secret),
+            "agent_user_token_set": bool(settings.github_agent_user_token),
+        },
+        "chat_dispatch": {
+            "backend": resolve_chat_execution_backend(policy),
+            "agent_user_token_required": resolve_chat_execution_backend(policy)
+            == "github_coding_agent",
+            "agent_user_token_set": bool(settings.github_agent_user_token),
         },
         "app": {"ok": False},
         "repositories": [],
@@ -486,8 +872,12 @@ async def run_github_self_check() -> SelfCheckResponse:
             entry["error"] = str(exc)
         checks["repositories"].append(entry)
 
+    chat_dispatch_ok = True
+    if checks["chat_dispatch"]["agent_user_token_required"]:
+        chat_dispatch_ok = bool(settings.github_agent_user_token)
+
     return SelfCheckResponse(
-        ok=checks["app"]["ok"] and repos_ok,
+        ok=checks["app"]["ok"] and repos_ok and chat_dispatch_ok,
         checked_at=datetime.now(UTC).isoformat(),
         checks=checks,
     )
@@ -707,6 +1097,7 @@ def get_dashboard_data(limit: int = 50) -> dict[str, object]:
     return {
         "generated_at": datetime.now(UTC).isoformat(),
         "autonomy_mode": policy.autonomy.mode,
+        "chat_execution_backend": resolve_chat_execution_backend(policy),
         "task_count": len(task_items),
         "polling": polling,
         "model": {
@@ -732,6 +1123,7 @@ def chat_page(_admin: None = Depends(require_admin_token)) -> str:
     _, policy = load_policy()
     chat_config = {
         "adminTokenRequired": bool(settings.api_admin_token),
+        "executionBackend": resolve_chat_execution_backend(policy),
         "availableModels": available_chat_models(settings),
         "defaultModelSelection": serialize_chat_model_selection(
             settings=settings,
@@ -770,6 +1162,10 @@ def create_chat_session(
     metadata = dict(request_body.metadata)
     if request_body.approval_issue_number is not None:
         metadata["approval_issue_number"] = request_body.approval_issue_number
+    if request_body.base_branch:
+        metadata["base_branch"] = request_body.base_branch.strip()
+    if request_body.custom_agent:
+        metadata["custom_agent"] = request_body.custom_agent.strip()
     selected_model = validate_chat_model_selection(
         settings=settings,
         provider=request_body.model_provider,
@@ -919,12 +1315,41 @@ def list_chat_session_runs(
     }
 
 
-@app.post("/chat/sessions/{session_id}/execute")
-async def execute_chat_session(
+@app.post("/chat/sessions/{session_id}/prepare")
+async def prepare_chat_session(
+    session_id: str,
+    request_body: PrepareChatSessionRequest,
+    _admin: None = Depends(require_admin_token),
+) -> dict[str, object]:
+    prepared = await prepare_chat_dispatch_plan(
+        session_id=session_id,
+        request_body=request_body,
+        persist_message=True,
+    )
+    plan = prepared["plan"]
+    return {
+        "ok": True,
+        "backend": resolve_chat_execution_backend(prepared["policy"]),
+        "ready": plan.ready,
+        "summary": plan.summary,
+        "clarification_questions": plan.clarification_questions,
+        "target_repository": prepared["target_repository"],
+        "base_branch": prepared["base_branch"],
+        "custom_agent": prepared["custom_agent"],
+        "selected_model": prepared["selected_model"],
+        "issue_preview": {
+            "title": plan.issue_title,
+            "body_markdown": plan.issue_body_markdown,
+            "custom_instructions": plan.custom_instructions,
+        },
+    }
+
+
+async def _execute_chat_session_local_pipeline(
+    *,
     session_id: str,
     request_body: ExecuteChatSessionRequest,
-    _admin: None = Depends(require_admin_token),
-    x_operator: str | None = Header(default=None),
+    x_operator: str | None,
 ) -> dict[str, object]:
     settings = get_settings()
     _, policy = load_policy()
@@ -1089,6 +1514,181 @@ async def execute_chat_session(
         "source_installation_id": source_installation_id,
         "approval_issue_number": approval_issue_number,
         "selected_model": selected_model,
+    }
+
+
+@app.post("/chat/sessions/{session_id}/execute")
+async def execute_chat_session(
+    session_id: str,
+    request_body: ExecuteChatSessionRequest,
+    _admin: None = Depends(require_admin_token),
+    x_operator: str | None = Header(default=None),
+) -> dict[str, object]:
+    _, policy = load_policy()
+    backend = resolve_chat_execution_backend(policy)
+    if backend == "local_pipeline":
+        return await _execute_chat_session_local_pipeline(
+            session_id=session_id,
+            request_body=request_body,
+            x_operator=x_operator,
+        )
+
+    settings = get_settings()
+    if not settings.github_agent_user_token:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "GITHUB_AGENT_USER_TOKEN is required for github_coding_agent chat execution. "
+                "Use a fine-grained PAT or GitHub App user token as documented by GitHub."
+            ),
+        )
+
+    prepared = await prepare_chat_dispatch_plan(
+        session_id=session_id,
+        request_body=request_body,
+        persist_message=False,
+    )
+    plan: DispatchPlan = prepared["plan"]
+    if not plan.ready:
+        session_factory = create_session_factory()
+        with session_factory() as session:
+            repo = TaskRepository(session)
+            repo.append_chat_message(
+                session_id=session_id,
+                role="assistant",
+                content=build_dispatch_question_message(plan),
+                metadata={
+                    "kind": "dispatch_clarification_required",
+                    "clarification_questions": plan.clarification_questions,
+                    "target_repository": prepared["target_repository"],
+                    "base_branch": prepared["base_branch"],
+                },
+            )
+        return {
+            "ok": False,
+            "dispatched": False,
+            "ready": False,
+            "clarification_required": True,
+            "summary": plan.summary,
+            "clarification_questions": plan.clarification_questions,
+            "target_repository": prepared["target_repository"],
+            "base_branch": prepared["base_branch"],
+            "selected_model": prepared["selected_model"],
+            "backend": "github_coding_agent",
+        }
+
+    operator = normalize_operator_identity(x_operator, fallback="chat-ui")
+    task_title = (
+        request_body.title or str((prepared["chat_session"] or {}).get("title") or "Chat execution")
+    ).strip() or "Chat execution"
+    target_repository = str(prepared["target_repository"])
+    base_branch = str(prepared["base_branch"])
+    selected_model = prepared["selected_model"]
+    custom_agent = prepared["custom_agent"]
+    transcript = str(prepared["transcript"])
+    issue_body = build_github_agent_issue_body(
+        transcript=transcript,
+        prepared_body=plan.issue_body_markdown,
+        target_repository=target_repository,
+        base_branch=base_branch,
+    )
+    dispatch_model = (
+        str(selected_model.get("model"))
+        if isinstance(selected_model, dict) and selected_model.get("provider") == "github"
+        else None
+    )
+
+    github = GitHubAppService(
+        settings.github_app_id,
+        settings.github_private_key,
+        api_base_url=settings.github_api_base_url,
+    )
+    labels = ["agentic", "agentic-dispatch"]
+    try:
+        issue = await github.create_issue_with_coding_agent(
+            target_repository,
+            settings.github_agent_user_token,
+            title=plan.issue_title or task_title,
+            body=issue_body,
+            base_branch=base_branch,
+            labels=labels,
+            custom_instructions=plan.custom_instructions,
+            custom_agent=custom_agent,
+            model=dispatch_model,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to dispatch issue to GitHub coding agent: {exc}",
+        ) from exc
+    issue_number = int(issue.get("number") or 0)
+    issue_url = str(issue.get("html_url") or "")
+
+    session_factory = create_session_factory()
+    with session_factory() as session:
+        repo = TaskRepository(session)
+        payload = build_chat_dispatch_payload(
+            session_id=session_id,
+            task_title=task_title,
+            transcript=transcript,
+            operator=operator,
+            target_repository=target_repository,
+            source_repository=str(policy.system.control_repository or "chat-ui"),
+            base_branch=base_branch,
+            selected_model=selected_model,
+            dispatch_plan=plan,
+            issue_number=issue_number,
+            issue_url=issue_url,
+            issue_labels=labels,
+        )
+        task_id, run_id = create_dispatch_audit_record(
+            repo=repo,
+            task_title=task_title,
+            payload=payload,
+            dispatch_plan=plan,
+            issue_number=issue_number,
+            issue_url=issue_url,
+            target_repository=target_repository,
+            base_branch=base_branch,
+            selected_model=selected_model,
+        )
+        repo.append_chat_message(
+            session_id=session_id,
+            role="system",
+            content=(
+                f"Dispatched to GitHub coding agent in {target_repository}: issue #{issue_number}"
+                f" ({issue_url})"
+            ),
+            metadata={
+                "kind": "github_agent_dispatch",
+                "task_id": task_id,
+                "run_id": run_id,
+                "issue_number": issue_number,
+                "issue_url": issue_url,
+                "target_repository": target_repository,
+                "base_branch": base_branch,
+                "selected_model": selected_model,
+                "custom_agent": custom_agent,
+            },
+        )
+
+    return {
+        "ok": True,
+        "dispatched": True,
+        "backend": "github_coding_agent",
+        "task_id": task_id,
+        "run_id": run_id,
+        "state": TaskState.DELEGATED.value,
+        "target_repository": target_repository,
+        "base_branch": base_branch,
+        "selected_model": selected_model,
+        "custom_agent": custom_agent,
+        "summary": plan.summary,
+        "issue": {
+            "number": issue_number,
+            "url": issue_url,
+            "repository": target_repository,
+        },
     }
 
 

--- a/src/agentic_coder/config.py
+++ b/src/agentic_coder/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     github_private_key: str = ""
     github_private_key_path: Path | None = None
     github_api_base_url: str = "https://api.github.com"
+    github_agent_user_token: str = ""
     github_models_api_key: str = ""
     github_models_base_url: str = "https://models.inference.ai.azure.com"
     github_models_chat_model: str = "gpt-4.1-mini"

--- a/src/agentic_coder/db/repositories.py
+++ b/src/agentic_coder/db/repositories.py
@@ -384,6 +384,7 @@ class TaskRepository:
 
     def get_active_chat_task(self, *, session_id: str) -> TaskRecord | None:
         terminal_states = (
+            TaskState.DELEGATED.value,
             TaskState.SUCCEEDED.value,
             TaskState.FAILED.value,
             TaskState.CANCELLED.value,

--- a/src/agentic_coder/domain/tasks.py
+++ b/src/agentic_coder/domain/tasks.py
@@ -12,6 +12,7 @@ class TaskState(StrEnum):
     AWAITING_APPROVAL = "awaiting_approval"
     READY = "ready"
     RUNNING = "running"
+    DELEGATED = "delegated"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     CANCELLED = "cancelled"

--- a/src/agentic_coder/github_app/service.py
+++ b/src/agentic_coder/github_app/service.py
@@ -24,6 +24,11 @@ class WebhookVerifier:
 
 
 class GitHubAppService:
+    CODING_AGENT_ASSIGNEE = "copilot-swe-agent[bot]"
+    CODING_AGENT_FEATURES = (
+        "issues_copilot_assignment_api_support,coding_agent_model_selection"
+    )
+
     def __init__(
         self,
         app_id: str,
@@ -290,6 +295,45 @@ class GitHubAppService:
         response.raise_for_status()
         return response.json()
 
+    async def create_issue_with_coding_agent(
+        self,
+        repository: str,
+        user_token: str,
+        *,
+        title: str,
+        body: str,
+        base_branch: str,
+        labels: list[str] | None = None,
+        custom_instructions: str = "",
+        custom_agent: str | None = None,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self.api_base_url}/repos/{repository}/issues"
+        headers = self._user_headers(user_token)
+        payload: dict[str, Any] = {
+            "title": title,
+            "body": body,
+            "assignees": [self.CODING_AGENT_ASSIGNEE],
+            "agentAssignment": {
+                "target_repo": repository,
+                "base_branch": base_branch,
+            },
+        }
+        if labels:
+            payload["labels"] = labels
+        if custom_instructions.strip():
+            payload["agentAssignment"]["custom_instructions"] = custom_instructions.strip()
+        if custom_agent and custom_agent.strip():
+            payload["agentAssignment"]["custom_agent"] = custom_agent.strip()
+        if model and model.strip():
+            payload["agentAssignment"]["model"] = model.strip()
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=headers, json=payload)
+
+        response.raise_for_status()
+        return response.json()
+
     async def add_issue_labels(
         self,
         repository: str,
@@ -380,4 +424,13 @@ class GitHubAppService:
             "Authorization": f"Bearer {installation_token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    @classmethod
+    def _user_headers(cls, user_token: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {user_token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "GraphQL-Features": cls.CODING_AGENT_FEATURES,
         }

--- a/src/agentic_coder/orchestration/state_machine.py
+++ b/src/agentic_coder/orchestration/state_machine.py
@@ -10,10 +10,12 @@ TRANSITIONS: dict[TaskState, set[TaskState]] = {
     TaskState.RUNNING: {
         TaskState.AWAITING_APPROVAL,
         TaskState.READY,
+        TaskState.DELEGATED,
         TaskState.SUCCEEDED,
         TaskState.FAILED,
         TaskState.CANCELLED,
     },
+    TaskState.DELEGATED: set(),
     TaskState.SUCCEEDED: set(),
     TaskState.FAILED: set(),
     TaskState.CANCELLED: set(),

--- a/src/agentic_coder/policy/models.py
+++ b/src/agentic_coder/policy/models.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, model_validator
 
 AutonomyMode = Literal["gated", "autonomous"]
 TriggerMode = Literal["webhook", "polling", "hybrid"]
+ChatExecutionBackend = Literal["github_coding_agent", "local_pipeline"]
 
 
 class SystemPolicy(BaseModel):
@@ -57,6 +58,11 @@ class BudgetPolicy(BaseModel):
     max_parallel_candidates: int = 1
 
 
+class ChatPolicy(BaseModel):
+    execution_backend: ChatExecutionBackend = "github_coding_agent"
+    auto_prepare: bool = True
+
+
 class AgenticPolicy(BaseModel):
     version: int = 1
     system: SystemPolicy = Field(default_factory=SystemPolicy)
@@ -66,6 +72,7 @@ class AgenticPolicy(BaseModel):
     trigger: TriggerPolicy = Field(default_factory=TriggerPolicy)
     knowledge_graph: KnowledgeGraphPolicy = Field(default_factory=KnowledgeGraphPolicy)
     budgets: BudgetPolicy = Field(default_factory=BudgetPolicy)
+    chat: ChatPolicy = Field(default_factory=ChatPolicy)
 
     @model_validator(mode="after")
     def validate_autonomy_mode(self) -> "AgenticPolicy":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -480,12 +480,26 @@ class _ChatPolicy:
         fallback_provider = None
         embedding_provider = "github"
 
+    class chat:  # noqa: N801
+        execution_backend = "github_coding_agent"
+        auto_prepare = True
+
+
+class _LocalChatPolicy(_ChatPolicy):
+    class chat:  # noqa: N801
+        execution_backend = "local_pipeline"
+        auto_prepare = False
+
 
 class _ChatExecutionRepo:
     created_payload: dict[str, object] | None = None
     appended_messages: list[dict[str, object]] = []
     session_metadata: dict[str, object] = {}
     updated_metadata: dict[str, object] | None = None
+    run_events: list[tuple[str, dict[str, object]]] = []
+    state_updates: list[str] = []
+    run_metadata: dict[str, object] | None = None
+    completed_status: str | None = None
 
     def __init__(self, session) -> None:  # noqa: ANN001
         self.session = session
@@ -537,6 +551,35 @@ class _ChatExecutionRepo:
             updated_at=now,
         )
 
+    def create_run(self, task_id: str, worker_name: str) -> str:
+        _ = task_id, worker_name
+        return "run-1"
+
+    def update_state(self, task_id: str, state: TaskState, **kwargs) -> TaskRecord | None:  # noqa: ANN003
+        _ = kwargs
+        self.__class__.state_updates.append(state.value)
+        now = datetime.now(UTC)
+        return TaskRecord(
+            task_id=task_id,
+            title="Enterprise request",
+            payload=self.__class__.created_payload or {},
+            state=state,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def append_run_event(self, run_id: str, event_type: str, payload: dict[str, object]) -> None:
+        _ = run_id
+        self.__class__.run_events.append((event_type, dict(payload)))
+
+    def update_run_metadata(self, run_id: str, metadata: dict[str, object]) -> None:
+        _ = run_id
+        self.__class__.run_metadata = dict(metadata)
+
+    def complete_run(self, run_id: str, status: str) -> None:
+        _ = run_id
+        self.__class__.completed_status = status
+
     def append_chat_message(
         self,
         *,
@@ -577,13 +620,17 @@ class _ChatExecutionRepo:
         }
 
 
-def test_execute_chat_session_requires_issue_number_when_gated(monkeypatch) -> None:
+def test_prepare_chat_session_returns_clarification_questions(monkeypatch) -> None:
     from agentic_coder.api import main
 
     _ChatExecutionRepo.created_payload = None
     _ChatExecutionRepo.appended_messages = []
     _ChatExecutionRepo.session_metadata = {}
     _ChatExecutionRepo.updated_metadata = None
+    _ChatExecutionRepo.run_events = []
+    _ChatExecutionRepo.state_updates = []
+    _ChatExecutionRepo.run_metadata = None
+    _ChatExecutionRepo.completed_status = None
     monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
     monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
     monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
@@ -595,31 +642,261 @@ def test_execute_chat_session_requires_issue_number_when_gated(monkeypatch) -> N
             (),
             {
                 "api_admin_token": "",
+                "github_agent_user_token": "ghu-test",
+                "github_app_id": "1",
+                "github_private_key": "private-key",
+                "github_api_base_url": "https://api.github.com",
+                "model_request_timeout_seconds": 40.0,
+                "github_models_base_url": "https://models.inference.ai.azure.com",
+                "ollama_base_url": "http://ollama:11434",
                 "github_models_api_key": "ghp-test",
                 "github_models_chat_model": "Phi-4",
                 "ollama_chat_model": "llama3.1:8b",
             },
         )(),
     )
+    monkeypatch.setattr(
+        main.ChatManagerAgent,
+        "prepare_dispatch",
+        lambda self, **kwargs: main.DispatchPlan(  # noqa: ARG005
+            ready=False,
+            summary="Need decisions on rollout scope.",
+            issue_title="Improve predictiv",
+            issue_body_markdown="",
+            custom_instructions="",
+            clarification_questions=[
+                "Should this ship as one PR or staged work?",
+                "Can backend behavior change for existing users?",
+            ],
+        ),
+    )
+
+    response = client.post(
+        "/chat/sessions/chat-1/prepare",
+        json={"base_branch": "develop", "custom_agent": "frontend-designer"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ready"] is False
+    assert len(data["clarification_questions"]) == 2
+    assert data["base_branch"] == "develop"
+    assert data["custom_agent"] == "frontend-designer"
+    assert _ChatExecutionRepo.updated_metadata is not None
+    assert _ChatExecutionRepo.updated_metadata["base_branch"] == "develop"
+    assert _ChatExecutionRepo.updated_metadata["custom_agent"] == "frontend-designer"
+    assert _ChatExecutionRepo.appended_messages[-1]["role"] == "assistant"
+
+
+def test_execute_chat_session_dispatches_to_github_agent(monkeypatch) -> None:
+    from agentic_coder.api import main
+
+    _ChatExecutionRepo.created_payload = None
+    _ChatExecutionRepo.appended_messages = []
+    _ChatExecutionRepo.session_metadata = {"base_branch": "develop"}
+    _ChatExecutionRepo.updated_metadata = None
+    _ChatExecutionRepo.run_events = []
+    _ChatExecutionRepo.state_updates = []
+    _ChatExecutionRepo.run_metadata = None
+    _ChatExecutionRepo.completed_status = None
+
+    monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
+    monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
+    monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
+    monkeypatch.setattr(
+        main,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "api_admin_token": "",
+                "github_agent_user_token": "ghu-test",
+                "github_app_id": "1",
+                "github_private_key": "private-key",
+                "github_api_base_url": "https://api.github.com",
+                "model_request_timeout_seconds": 40.0,
+                "github_models_base_url": "https://models.inference.ai.azure.com",
+                "ollama_base_url": "http://ollama:11434",
+                "github_models_api_key": "ghp-test",
+                "github_models_chat_model": "Phi-4",
+                "ollama_chat_model": "llama3.1:8b",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        main.ChatManagerAgent,
+        "prepare_dispatch",
+        lambda self, **kwargs: main.DispatchPlan(  # noqa: ARG005
+            ready=True,
+            summary="Dispatch ready for predictiv onboarding improvements.",
+            issue_title="Improve onboarding flow",
+            issue_body_markdown="## Objective\nShip onboarding improvements.",
+            custom_instructions="Keep the first PR scoped to onboarding flow changes.",
+            clarification_questions=[],
+        ),
+    )
+
+    class _DispatchGithub:
+        calls: list[dict[str, object]] = []
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            _ = args, kwargs
+
+        async def create_issue_with_coding_agent(
+            self,
+            repository: str,
+            user_token: str,
+            *,
+            title: str,
+            body: str,
+            base_branch: str,
+            labels: list[str] | None = None,
+            custom_instructions: str = "",
+            custom_agent: str | None = None,
+            model: str | None = None,
+        ) -> dict[str, object]:
+            self.__class__.calls.append(
+                {
+                    "repository": repository,
+                    "user_token": user_token,
+                    "title": title,
+                    "body": body,
+                    "base_branch": base_branch,
+                    "labels": labels or [],
+                    "custom_instructions": custom_instructions,
+                    "custom_agent": custom_agent,
+                    "model": model,
+                }
+            )
+            return {
+                "number": 77,
+                "html_url": "https://github.com/acme/predictiv/issues/77",
+            }
+
+    monkeypatch.setattr(main, "GitHubAppService", _DispatchGithub)
+
+    response = client.post(
+        "/chat/sessions/chat-1/execute",
+        json={
+            "model_provider": "github",
+            "model_name": "gpt-4.1",
+            "base_branch": "develop",
+            "custom_agent": "frontend-designer",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dispatched"] is True
+    assert data["task_id"] == "chat-task-1"
+    assert data["run_id"] == "run-1"
+    assert data["state"] == "delegated"
+    assert data["issue"]["number"] == 77
+    assert data["selected_model"]["provider"] == "github"
+    assert data["selected_model"]["model"] == "gpt-4.1"
+    assert data["selected_model"]["costTier"] == "1x"
+    assert data["custom_agent"] == "frontend-designer"
+
+    assert _ChatExecutionRepo.created_payload is not None
+    payload = _ChatExecutionRepo.created_payload
+    assert payload["source_repository"] == "acme/control"
+    assert payload["dispatch_backend"] == "github_coding_agent"
+    assert payload["dispatch_issue_number"] == 77
+    assert payload["dispatch_issue_url"] == "https://github.com/acme/predictiv/issues/77"
+    assert payload["dispatch_base_branch"] == "develop"
+    assert payload["dispatch_model"] == "gpt-4.1"
+    assert payload["dispatch_model_provider"] == "github"
+    assert payload["dispatch_model_cost_tier"] == "1x"
+    assert _ChatExecutionRepo.updated_metadata == {
+        "base_branch": "develop",
+        "custom_agent": "frontend-designer",
+        "model_selection": {"provider": "github", "model": "gpt-4.1"},
+        "last_dispatch_plan": {
+            "ready": True,
+            "summary": "Dispatch ready for predictiv onboarding improvements.",
+            "issue_title": "Improve onboarding flow",
+            "custom_instructions": "Keep the first PR scoped to onboarding flow changes.",
+            "clarification_questions": [],
+            "prepared_at": _ChatExecutionRepo.updated_metadata["last_dispatch_plan"]["prepared_at"],
+        },
+    }
+    assert _ChatExecutionRepo.state_updates[-1] == "delegated"
+    assert _ChatExecutionRepo.completed_status == "succeeded"
+    assert any(event[0] == "github_agent_dispatched" for event in _ChatExecutionRepo.run_events)
+    assert _DispatchGithub.calls[0]["custom_agent"] == "frontend-designer"
+    assert _DispatchGithub.calls[0]["model"] == "gpt-4.1"
+
+
+def test_execute_chat_session_returns_clarification_when_not_ready(monkeypatch) -> None:
+    from agentic_coder.api import main
+
+    _ChatExecutionRepo.created_payload = None
+    _ChatExecutionRepo.appended_messages = []
+    _ChatExecutionRepo.session_metadata = {}
+    _ChatExecutionRepo.updated_metadata = None
+    _ChatExecutionRepo.run_events = []
+    _ChatExecutionRepo.state_updates = []
+    _ChatExecutionRepo.run_metadata = None
+    _ChatExecutionRepo.completed_status = None
+    monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
+    monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
+    monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
+    monkeypatch.setattr(
+        main,
+        "get_settings",
+        lambda: type(
+            "_Settings",
+            (),
+            {
+                "api_admin_token": "",
+                "github_agent_user_token": "ghu-test",
+                "github_app_id": "1",
+                "github_private_key": "private-key",
+                "github_api_base_url": "https://api.github.com",
+                "model_request_timeout_seconds": 40.0,
+                "github_models_base_url": "https://models.inference.ai.azure.com",
+                "ollama_base_url": "http://ollama:11434",
+                "github_models_api_key": "ghp-test",
+                "github_models_chat_model": "Phi-4",
+                "ollama_chat_model": "llama3.1:8b",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        main.ChatManagerAgent,
+        "prepare_dispatch",
+        lambda self, **kwargs: main.DispatchPlan(  # noqa: ARG005
+            ready=False,
+            summary="Need one more decision.",
+            issue_title="Improve predictiv",
+            issue_body_markdown="",
+            custom_instructions="",
+            clarification_questions=["Should this include backend changes?"],
+        ),
+    )
 
     response = client.post("/chat/sessions/chat-1/execute", json={})
 
-    assert response.status_code == 400
+    assert response.status_code == 200
     data = response.json()
-    assert "approval_issue_number" in str(data["detail"])
+    assert data["dispatched"] is False
+    assert data["clarification_required"] is True
+    assert data["clarification_questions"] == ["Should this include backend changes?"]
+    assert _ChatExecutionRepo.created_payload is None
+    assert _ChatExecutionRepo.appended_messages[-1]["role"] == "assistant"
 
 
-def test_execute_chat_session_routes_source_and_target_installations(monkeypatch) -> None:
+def test_execute_chat_session_local_pipeline_fallback(monkeypatch) -> None:
     from agentic_coder.api import main
 
     _ChatExecutionRepo.created_payload = None
     _ChatExecutionRepo.appended_messages = []
     _ChatExecutionRepo.session_metadata = {"approval_issue_number": 77}
     _ChatExecutionRepo.updated_metadata = None
-
     monkeypatch.setattr(main, "TaskRepository", _ChatExecutionRepo)
     monkeypatch.setattr(main, "create_session_factory", lambda: _FakeSessionFactory())
-    monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _ChatPolicy()))
+    monkeypatch.setattr(main, "load_policy", lambda: (Path("agentic.yaml"), _LocalChatPolicy()))
     monkeypatch.setattr(
         main,
         "get_settings",
@@ -658,22 +935,3 @@ def test_execute_chat_session_routes_source_and_target_installations(monkeypatch
     assert data["approval_issue_number"] == 77
     assert data["source_installation_id"] == 111
     assert data["target_installation_id"] == 222
-    assert data["selected_model"]["provider"] == "github"
-    assert data["selected_model"]["model"] == "gpt-4.1"
-    assert data["selected_model"]["costTier"] == "1x"
-    assert fake_queue.enqueued == ["chat-task-1"]
-
-    assert _ChatExecutionRepo.created_payload is not None
-    payload = _ChatExecutionRepo.created_payload
-    assert payload["source_repository"] == "acme/control"
-    assert payload["source_installation_id"] == 111
-    assert payload["target_installation_id"] == 222
-    assert payload["installation_id"] == 222
-    assert payload["issue_number"] == 77
-    assert payload["model_provider"] == "github"
-    assert payload["model_name"] == "gpt-4.1"
-    assert payload["model_cost_tier"] == "1x"
-    assert _ChatExecutionRepo.updated_metadata == {
-        "approval_issue_number": 77,
-        "model_selection": {"provider": "github", "model": "gpt-4.1"},
-    }

--- a/tests/test_github_app_service.py
+++ b/tests/test_github_app_service.py
@@ -17,6 +17,8 @@ class _FakeResponse:
 
 
 class _FakeAsyncClient:
+    last_request: tuple[str, str, dict[str, str], dict[str, object] | None] | None = None
+
     def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         self.requests: list[tuple[str, str, dict[str, object] | None]] = []
 
@@ -32,12 +34,22 @@ class _FakeAsyncClient:
         headers: dict[str, str],
         json: dict[str, object] | None = None,
     ):
-        _ = headers
+        self.__class__.last_request = ("POST", url, dict(headers), dict(json or {}))
         self.requests.append(("POST", url, json))
         if url.endswith("/access_tokens"):
             return _FakeResponse(201, {"token": "inst-token"})
         if url.endswith("/git/refs"):
             return _FakeResponse(201, {"ref": "refs/heads/feature/test"})
+        if url.endswith("/issues"):
+            return _FakeResponse(
+                201,
+                {
+                    "id": 21,
+                    "number": 5,
+                    "html_url": "https://github.com/acme/widgets/issues/5",
+                    "state": "open",
+                },
+            )
         if url.endswith("/pulls"):
             return _FakeResponse(
                 201,
@@ -126,3 +138,47 @@ def test_normalize_issue_comment_resolves_bare_repo_name_to_source_owner() -> No
 
     assert normalized.source_repository == "acme/control"
     assert normalized.target_repository == "acme/predictiv"
+
+
+@pytest.mark.asyncio
+async def test_create_issue_with_coding_agent_uses_user_token_and_assignment_payload(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("agentic_coder.github_app.service.httpx.AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.last_request = None
+
+    service = GitHubAppService(
+        app_id="1",
+        private_key="test-key",
+        api_base_url="https://api.github.com",
+    )
+
+    issue = await service.create_issue_with_coding_agent(
+        "acme/widgets",
+        "ghu-test",
+        title="Improve onboarding",
+        body="Ship the onboarding refresh.",
+        base_branch="develop",
+        labels=["agentic", "agentic-dispatch"],
+        custom_instructions="Keep the first PR small.",
+        custom_agent="frontend-designer",
+        model="gpt-4.1",
+    )
+
+    assert issue["number"] == 5
+    assert _FakeAsyncClient.last_request is not None
+
+    method, url, headers, payload = _FakeAsyncClient.last_request
+    assert method == "POST"
+    assert url == "https://api.github.com/repos/acme/widgets/issues"
+    assert headers["Authorization"] == "Bearer ghu-test"
+    assert headers["GraphQL-Features"] == GitHubAppService.CODING_AGENT_FEATURES
+    assert payload["assignees"] == [GitHubAppService.CODING_AGENT_ASSIGNEE]
+    assert payload["labels"] == ["agentic", "agentic-dispatch"]
+    assert payload["agentAssignment"] == {
+        "target_repo": "acme/widgets",
+        "base_branch": "develop",
+        "custom_instructions": "Keep the first PR small.",
+        "custom_agent": "frontend-designer",
+        "model": "gpt-4.1",
+    }


### PR DESCRIPTION
## Summary
- pivot the chat product toward clarification and dispatch into GitHub coding agent
- keep the local worker pipeline as a fallback backend instead of the default path
- update the chat UI, dashboard, smoke coverage, and product docs to match the new operating model

## Validation
- make test-regression
- make smoke