### PR TITLE
Fix chat dispatch audit transition path

### DIFF
--- a/src/agentic_coder/orchestration/state_machine.py
+++ b/src/agentic_coder/orchestration/state_machine.py
@@ -2,7 +2,12 @@ from agentic_coder.domain.tasks import TaskRecord, TaskState
 
 TRANSITIONS: dict[TaskState, set[TaskState]] = {
     TaskState.RECEIVED: {TaskState.NORMALIZED, TaskState.FAILED, TaskState.CANCELLED},
-    TaskState.NORMALIZED: {TaskState.INDEXED, TaskState.FAILED, TaskState.CANCELLED},
+    TaskState.NORMALIZED: {
+        TaskState.INDEXED,
+        TaskState.PLANNED,
+        TaskState.FAILED,
+        TaskState.CANCELLED,
+    },
     TaskState.INDEXED: {TaskState.PLANNED, TaskState.FAILED, TaskState.CANCELLED},
     TaskState.PLANNED: {TaskState.RUNNING, TaskState.FAILED, TaskState.CANCELLED},
     TaskState.AWAITING_APPROVAL: {TaskState.READY, TaskState.FAILED, TaskState.CANCELLED},

--- a/tests/test_task_state_machine.py
+++ b/tests/test_task_state_machine.py
@@ -19,3 +19,15 @@ def test_invalid_task_transition() -> None:
 
     with pytest.raises(InvalidTaskTransitionError):
         machine.transition(task, TaskState.RUNNING)
+
+
+def test_chat_dispatch_transition_path() -> None:
+    task = TaskRecord(task_id="1", title="Dispatch task", payload={})
+    machine = TaskStateMachine()
+
+    machine.transition(task, TaskState.NORMALIZED)
+    machine.transition(task, TaskState.PLANNED)
+    machine.transition(task, TaskState.RUNNING)
+    machine.transition(task, TaskState.DELEGATED)
+
+    assert task.state == TaskState.DELEGATED


### PR DESCRIPTION
## Summary
- allow the delegated chat audit path to transition from normalized to planned
- add regression coverage for the chat dispatch transition sequence

## Why
A live GitHub-agent dispatch exposed that the local audit path skipped indexing and failed on .

## Validation
- PYTEST_ADDOPTS='-p no:cacheprovider' pytest tests/test_task_state_machine.py tests/test_api.py tests/test_github_app_service.py -q
- live chat dispatch to predictiv from /chat