### PR TITLE
Align predictiv base branch with GitHub

### DIFF
--- a/agentic.yaml
+++ b/agentic.yaml
@@ -11,8 +11,8 @@ system:
     italnstallion789/predictiv: /repos/predictiv
   default_target_base_branch: develop
   target_base_branches:
-    italnstallion789/predictiv: develop
-    predictiv: develop
+    italnstallion789/predictiv: master
+    predictiv: master
 autonomy:
   mode: gated
   allowed_actions:


### PR DESCRIPTION
## Summary
- align `predictiv` base-branch policy with the repository's actual GitHub default branch
- keep chat prepare/dispatch from defaulting to `develop` for `predictiv`

## Validation
- `gh repo view italnstallion789/predictiv --json defaultBranchRef`
- `GET /policy`
- live chat prepare without a base-branch override returned `master`
