### PR TITLE
Route predictiv chat dispatches to develop

### DIFF
--- a/agentic.yaml
+++ b/agentic.yaml
@@ -11,8 +11,8 @@ system:
     italnstallion789/predictiv: /repos/predictiv
   default_target_base_branch: develop
   target_base_branches:
-    italnstallion789/predictiv: master
-    predictiv: master
+    italnstallion789/predictiv: develop
+    predictiv: develop
 autonomy:
   mode: gated
   allowed_actions:


### PR DESCRIPTION
## Summary
- restore `predictiv` chat dispatch defaults to `develop`
- keep `predictiv` feature-branch work targeting the integration branch instead of `master`

## Validation
- `gh api repos/italnstallion789/predictiv/branches/develop`
- `gh pr list -R italnstallion789/predictiv --state merged`
- `GET /policy`
- live `/chat` prepare without a base-branch override returned `develop`
